### PR TITLE
feat: Add default email styles and font for discount reminder email

### DIFF
--- a/Core/Emails/Settings/DiscountNotifySetting.php
+++ b/Core/Emails/Settings/DiscountNotifySetting.php
@@ -103,6 +103,8 @@ class DiscountNotifySetting extends Emails
 
         $generalSettings = (new GeneralSettings);
 
+        $styles = $this->getDefaultStyles();
+
         $discountNotify = $this;
 
         $data = [
@@ -110,6 +112,7 @@ class DiscountNotifySetting extends Emails
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
             'discountNotify' => $discountNotify,
+            'styles' => $styles
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/discount-notify.php';

--- a/Core/Emails/Settings/DiscountNotifySetting.php
+++ b/Core/Emails/Settings/DiscountNotifySetting.php
@@ -104,7 +104,6 @@ class DiscountNotifySetting extends Emails
         $generalSettings = (new GeneralSettings);
 
         $styles = $this->getDefaultStyles();
-
         $discountNotify = $this;
 
         $data = [

--- a/Core/Emails/Settings/DiscountReminderEmailSetting.php
+++ b/Core/Emails/Settings/DiscountReminderEmailSetting.php
@@ -107,7 +107,7 @@ class DiscountReminderEmailSetting extends Emails
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
             'discountReminder' => $discountReminder,
-            'bg-color' => $styles,
+            'styles' => $styles
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/discount-reminder.php';

--- a/Core/Emails/Settings/DiscountReminderEmailSetting.php
+++ b/Core/Emails/Settings/DiscountReminderEmailSetting.php
@@ -99,7 +99,6 @@ class DiscountReminderEmailSetting extends Emails
         $generalSettings = (new GeneralSettings);
 
         $styles = $this->getDefaultStyles();
-
         $discountReminder = $this;
 
         $data = [

--- a/Core/Emails/Settings/DiscountReminderEmailSetting.php
+++ b/Core/Emails/Settings/DiscountReminderEmailSetting.php
@@ -98,6 +98,8 @@ class DiscountReminderEmailSetting extends Emails
 
         $generalSettings = (new GeneralSettings);
 
+        $styles = $this->getDefaultStyles();
+
         $discountReminder = $this;
 
         $data = [
@@ -105,6 +107,7 @@ class DiscountReminderEmailSetting extends Emails
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
             'discountReminder' => $discountReminder,
+            'bg-color' => $styles,
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/discount-reminder.php';

--- a/Core/Emails/Settings/Emails.php
+++ b/Core/Emails/Settings/Emails.php
@@ -97,7 +97,7 @@ abstract class Emails
             'email_text_color' => '#FADFDB',
             'button_bg_color' => '#EACCAE',
             'button_text_color' => '#000000',
-            'button_border_color' => '#000000',
+            'button_border_color' => '#ffffff',
         ];
     }
 }

--- a/Core/Emails/Settings/Emails.php
+++ b/Core/Emails/Settings/Emails.php
@@ -89,4 +89,15 @@ abstract class Emails
 
         return $settings;
     }
+
+    public function getDefaultStyles()
+    {
+        return [
+            'email_bg_color' => '#BCE5A1',
+            'email_text_color' => '#FADFDB',
+            'button_bg_color' => '#EACCAE',
+            'button_text_color' => '#000000',
+            'button_border_color' => '#000000',
+        ];
+    }
 }

--- a/Core/Emails/Settings/PhotoRequest.php
+++ b/Core/Emails/Settings/PhotoRequest.php
@@ -83,7 +83,7 @@ class PhotoRequest extends Emails
 
     public function getDiscountText()
     {
-        $this->getValue('discount_text');
+        return $this->getValue('discount_text');
     }
 
     public function getTemplatePreview()
@@ -96,13 +96,16 @@ class PhotoRequest extends Emails
 
         $generalSettings = (new GeneralSettings);
 
+        $styles = $this->getDefaultStyles();
+
         $photoRequest = $this;
 
         $data = [
             'order' => $order,
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
-            'photoRequest' => $photoRequest
+            'photoRequest' => $photoRequest,
+            'styles' => $styles
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/photo-request.php';

--- a/Core/Emails/Settings/PhotoRequest.php
+++ b/Core/Emails/Settings/PhotoRequest.php
@@ -97,7 +97,6 @@ class PhotoRequest extends Emails
         $generalSettings = (new GeneralSettings);
 
         $styles = $this->getDefaultStyles();
-
         $photoRequest = $this;
 
         $data = [

--- a/Core/Emails/Settings/ReplyRequest.php
+++ b/Core/Emails/Settings/ReplyRequest.php
@@ -82,6 +82,8 @@ class ReplyRequest extends Emails
 
         $generalSettings = (new GeneralSettings);
 
+        $styles = $this->getDefaultStyles();
+
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/review-reply.php';
 
         $replyRequest = $this;
@@ -90,7 +92,8 @@ class ReplyRequest extends Emails
             'order' => $order,
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
-            'replyRequest' => $replyRequest
+            'replyRequest' => $replyRequest,
+            'styles' => $styles
         ];
 
         $html =  AssetHelper::renderTemplate($file, $data);

--- a/Core/Emails/Settings/ReplyRequest.php
+++ b/Core/Emails/Settings/ReplyRequest.php
@@ -83,7 +83,6 @@ class ReplyRequest extends Emails
         $generalSettings = (new GeneralSettings);
 
         $styles = $this->getDefaultStyles();
-
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/review-reply.php';
 
         $replyRequest = $this;

--- a/Core/Emails/Settings/ReviewReminderEmailSetting.php
+++ b/Core/Emails/Settings/ReviewReminderEmailSetting.php
@@ -112,7 +112,6 @@ class ReviewReminderEmailSetting extends Emails
         $generalSettings = new GeneralSettings;
 
         $styles = $this->getDefaultStyles();
-
         $discountReminder = $this;
 
         $data = [

--- a/Core/Emails/Settings/ReviewReminderEmailSetting.php
+++ b/Core/Emails/Settings/ReviewReminderEmailSetting.php
@@ -111,13 +111,16 @@ class ReviewReminderEmailSetting extends Emails
 
         $generalSettings = new GeneralSettings;
 
+        $styles = $this->getDefaultStyles();
+
         $discountReminder = $this;
 
         $data = [
             'order' => $order,
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
-            'discountReminder' => $discountReminder
+            'discountReminder' => $discountReminder,
+            'styles' => $styles
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/review-reminder.php';

--- a/Core/Emails/Settings/ReviewRequest.php
+++ b/Core/Emails/Settings/ReviewRequest.php
@@ -102,12 +102,13 @@ class ReviewRequest extends Emails
 
         $reviewRequest = new ReviewRequest(get_locale());
 
-
+        $styles = $this->getDefaultStyles();
         $data = [
             'order' => $order,
             'brandSettings' => $brandSettings,
             'generalSettings' => $generalSettings,
-            'reviewRequest' => $reviewRequest
+            'reviewRequest' => $reviewRequest,
+            'styles' => $styles
         ];
 
         $file = F_Review_PLUGIN_PATH . '/Core/Emails/views/review-request.php';

--- a/Core/Emails/Settings/ReviewRequest.php
+++ b/Core/Emails/Settings/ReviewRequest.php
@@ -101,7 +101,6 @@ class ReviewRequest extends Emails
         $generalSettings = (new GeneralSettings);
 
         $reviewRequest = new ReviewRequest(get_locale());
-
         $styles = $this->getDefaultStyles();
         $data = [
             'order' => $order,

--- a/Core/Emails/views/discount-notify.php
+++ b/Core/Emails/views/discount-notify.php
@@ -167,7 +167,7 @@
 
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#ffffff">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:0px auto;max-width:600px;">
@@ -184,7 +184,7 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="" width="NaN" bgcolor="#fadfdb">
+                                       style="" >
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
@@ -234,8 +234,8 @@
 
                             <!--[if mso | IE]>
                         <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style=""
+                                >
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                             <div style="margin:0px auto;border-radius:0 0 15px 15px;">
@@ -268,7 +268,7 @@
                                                                         role="presentation"
                                                                         style="border-collapse:separate;line-height:100%;">
                                                                         <tr>
-                                                                            <td align="center" bgcolor="#7c1b06" role="presentation"
+                                                                            <td align="center"  role="presentation"
                                                                                 href="{shop_page_url}"
                                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
@@ -301,14 +301,14 @@
                             <?php if ($generalSettings->isFooterEnabled()) ?>
                             <!--[if mso | IE]>
                         <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style=""
+                                >
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;">
+                            <div style="margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
+                                    style="width:100%;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -326,8 +326,8 @@
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                                                         <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;" role="presentation" >
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
@@ -338,12 +338,12 @@
                                                                 <tr>
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
+                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
                                                                             <p>{footer_text}</p>
                                                                             <a
                                                                                 data-cke-saved-href="http://localhost:7000"
                                                                                 href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
                                                                         </div>
                                                                     </td>
                                                                 </tr>

--- a/Core/Emails/views/discount-notify.php
+++ b/Core/Emails/views/discount-notify.php
@@ -86,7 +86,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="border:; border-radius: 15px 15px 15px 15px ;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="border:; border-radius: 15px 15px 15px 15px ;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>

--- a/Core/Emails/views/discount-notify.php
+++ b/Core/Emails/views/discount-notify.php
@@ -7,7 +7,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -83,8 +85,8 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#ffffff;">
-    <div style="background-color:#ffffff;">
+<body style="word-spacing:normal;">
+    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="border:; border-radius: 15px 15px 15px 15px ;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -168,12 +170,12 @@
            bgcolor="#ffffff">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
+                style="width:100%;">
                 <tbody>
                     <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                        <td style="direction:ltr;font-size:0px;text-align:center;">
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
@@ -182,20 +184,20 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
+                                       style="" width="NaN" bgcolor="#fadfdb">
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
+                                <div style="margin:0px auto;border-radius:15px 15px 0 0;">
                                     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
+                                        style="width:100%;border-radius:15px 15px 0 0;">
                                         <tbody>
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                                                <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
                                                     <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                            <td class="" style="vertical-align:top;"><![endif]-->
                                                     <div class="mj-column-per-100 mj-outlook-group-fix"
                                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
@@ -236,16 +238,16 @@
                                 width="NaN" bgcolor="#fadfdb">
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
+                            <div style="margin:0px auto;border-radius:0 0 15px 15px;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
+                                    style="width:100%;border-radius:0 0 15px 15px;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
                                                 <!--[if mso | IE]>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                                <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-100 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
@@ -254,7 +256,7 @@
                                                             <tr>
                                                                 <td align="left"
                                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
+                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
                                                                         {body}
                                                                     </div>
                                                                 </td>
@@ -268,10 +270,10 @@
                                                                         <tr>
                                                                             <td align="center" bgcolor="#7c1b06" role="presentation"
                                                                                 href="{shop_page_url}"
-                                                                                style="border:4px solid #ab5959;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#7c1b06;"
+                                                                                style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
                                                                                 <p
-                                                                                    style="display:inline-block;background:#7c1b06;color:#ffffff;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                                    style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
                                                                                     {discount_code}
                                                                                 </p>
                                                                             </td>
@@ -304,7 +306,7 @@
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
+                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                                     style="background:#ffffff;background-color:#ffffff;width:100%;">
                                     <tbody>
@@ -313,7 +315,7 @@
                                                 <!--[if mso | IE]>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                                <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-100 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <?php if ($generalSettings->isFooterEnabled()): ?>

--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -7,7 +7,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -93,16 +95,16 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#EDE4E7;">
-    <div style="background-color:#EDE4E7;"><!--[if mso | IE]>
+<body style="word-spacing:normal;">
+    <div style="border-radius:0 0 15px 15px; background-color:<?php echo esc_attr($data['bg-color']['email_bg_color']); ?>; color:<?php echo esc_attr($data['bg-color']['email_text_color']); ?>;" ><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <?php if ($brandSettings->isLogoEnabled()): ?>
-            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;max-width:600px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
+                    style="width:100%;">
                     <tbody>
                         <tr>
                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -135,9 +137,9 @@
            bgcolor="#EDE4E7">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-            <div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
+                    style="width:100%;">
                     <tbody>
                         <tr>
                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -181,9 +183,9 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <?php if ($brandSettings->isEmailBannerEnabled()): ?>
-            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;border-radius:15px 15px 0 0;max-width:600px;">
+            <div style="margin:0px auto;border-radius:15px 15px 0 0;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;border-radius:15px 15px 0 0;">
+                    style="width:100%;border-radius:15px 15px 0 0;">
                     <tbody>
                         <tr>
                             <td style="direction:ltr;font-size:0px;padding:4px;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px;text-align:center;">
@@ -226,27 +228,27 @@
            bgcolor="#FFFFFF">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+                style="width:100%;">
                 <tbody>
                     <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                        <td style="direction:ltr;font-size:0px;text-align:center;">
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#FADFDB">
+                                       style= width="NaN" bgcolor="#FADFDB">
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                            <div style="background:#FADFDB;background-color:#FADFDB;margin:0px auto;max-width:NaNpx;">
+                            <div style="margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#FADFDB;background-color:#FADFDB;width:100%;">
+                                    style="width:100%;">
                                     <tbody>
                                         <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                                            <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
                                                 <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr></tr>
@@ -262,23 +264,23 @@
                            width="NaN" bgcolor="#F5CEE4">
                         <tr>
                             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;max-width:NaNpx;">
+                            <div style="margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
+                                    style="width:100%;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
                                                 <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                            <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-100 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         width="100%">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="background-color:#F5CEE4;vertical-align:top;padding:25px;padding-top:25px;padding-right:25px;padding-bottom:25px;padding-left:25px;">
+                                                                <td style="vertical-align:top;padding:25px;padding-top:25px;padding-right:25px;padding-bottom:25px;padding-left:25px;">
                                                                     <table border="0" cellpadding="0" cellspacing="0"
                                                                         role="presentation" width="100%">
                                                                         <tbody>
@@ -298,21 +300,21 @@
                                                     </table>
                                                 </div>
                                                 <!--[if mso | IE]></td>
-                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-70 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         width="100%">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="border:3px solid #E3E3E3;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
+                                                                <td style="border:3px solid <?php echo esc_attr($data['bg-color']['button_border_color']); ?>;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
                                                                     <table border="0" cellpadding="0" cellspacing="0"
                                                                         role="presentation" width="100%">
                                                                         <tbody>
                                                                             <tr>
                                                                                 <td align="center"
                                                                                     style="font-size:0px;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:#000000;">
+                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:<?php echo esc_attr($data['bg-color']['email_text_color']);?>;">
                                                                                         {discount_code}<span style="font-size:14px;"><br></span>
                                                                                     </div>
                                                                                 </td>
@@ -320,7 +322,7 @@
                                                                             <tr>
                                                                                 <td align="center"
                                                                                     style="font-size:0px;padding:2px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:#000000;">
+                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:<?php echo esc_attr($data['bg-color']['email_text_color']);?>;;">
                                                                                         Discount expires :{discount_expires}
                                                                                     </div>
                                                                                 </td>
@@ -349,9 +351,9 @@
            bgcolor="#F5CEE4">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;border-radius:0 0 15px 15px;max-width:600px;">
+        <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#F5CEE4;background-color:#F5CEE4;width:100%;border-radius:0 0 15px 15px;">
+                style="width:100%;border-radius:0 0 15px 15px;">
                 <tbody>
                     <tr>
                         <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -371,9 +373,9 @@
                                                     style="border-collapse:separate;line-height:100%;">
                                                     <tr>
                                                         <td align="center" bgcolor="#2B071C" role="presentation"
-                                                            style="border:3px solid #E86F96;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;background:#2B071C;"
+                                                            style="border:3px solid <?php echo esc_attr($data['bg-color']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
                                                             valign="middle">
-                                                            <p style="display:inline-block;background:#2B071C;color:#ffffff;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
+                                                            <p style="display:inline-block;background:<?php echo esc_attr($data['bg-color']['button_bg_color']); ?>;color:<?php echo esc_attr($data['bg-color']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
                                                                 {button_text}
                                                             </p>
                                                         </td>
@@ -397,7 +399,7 @@
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <?php if ($generalSettings->isFooterEnabled()): ?><div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
+                    style="width:100%;">
                     <tbody>
                         <tr>
                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -413,17 +415,17 @@
                                             <tr>
                                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                                     <p
-                                                        style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+                                                        style="border-top:solid 2px #000000;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #000000;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
 </td></tr></table><![endif]-->
                                                 </td>
                                             </tr>
                                             <tr>
                                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
+                                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
                                                         {footer_text}<br><br>
                                                         <a
                                                             data-cke-saved-href="http://localhost:7000" href="http://localhost:7000"
-                                                            style="color:#c2c2c2;">Unsubscribe</a><br>
+                                                            style="color:#000000;">Unsubscribe</a><br>
                                                     </div>
                                                 </td>
                                             </tr>

--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -96,7 +96,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="border-radius:15px 15px 15px 15px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>" ><!--[if mso | IE]>
+    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="border-radius:15px 15px 15px 15px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>" ><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            >
         <tr>

--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -134,7 +134,7 @@
             </div>
             <!--[if mso | IE]></td></tr></table>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#EDE4E7">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
             <div style="margin:0px auto;max-width:600px;">
@@ -179,7 +179,7 @@
         <?php endif; ?>
         <!--[if mso | IE]></td></tr></table>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <?php if ($brandSettings->isEmailBannerEnabled()): ?>
@@ -225,7 +225,7 @@
         <?php endif; ?>
         <!--[if mso | IE]></td></tr></table>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#FFFFFF">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:0px auto;max-width:600px;">
@@ -239,7 +239,7 @@
                         <tr>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style= width="NaN" bgcolor="#FADFDB">
+                                       style= "" >
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
@@ -261,7 +261,7 @@
                             <!--[if mso | IE]></td></tr></table></td>
                 <td class="" style="">
                     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                           width="NaN" bgcolor="#F5CEE4">
+                           >
                         <tr>
                             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                             <div style="margin:0px auto;">
@@ -348,7 +348,7 @@
         </div>
         <!--[if mso | IE]></td></tr></table>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:600px;">
@@ -372,7 +372,7 @@
                                                 <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                     style="border-collapse:separate;line-height:100%;">
                                                     <tr>
-                                                        <td align="center" bgcolor="#2B071C" role="presentation"
+                                                        <td align="center"  role="presentation"
                                                             style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
                                                             valign="middle">
                                                             <p style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
@@ -394,10 +394,10 @@
         </div>
         <!--[if mso | IE]></td></tr></table>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#EDE4E7">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($generalSettings->isFooterEnabled()): ?><div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
+        <?php if ($generalSettings->isFooterEnabled()): ?><div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                     style="width:100%;">
                     <tbody>
@@ -415,7 +415,7 @@
                                             <tr>
                                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                                     <p
-                                                        style="border-top:solid 2px #000000;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #000000;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+                                                        style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
 </td></tr></table><![endif]-->
                                                 </td>
                                             </tr>
@@ -425,7 +425,7 @@
                                                         {footer_text}<br><br>
                                                         <a
                                                             data-cke-saved-href="http://localhost:7000" href="http://localhost:7000"
-                                                            style="color:#000000;">Unsubscribe</a><br>
+                                                            style="">Unsubscribe</a><br>
                                                     </div>
                                                 </td>
                                             </tr>

--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
-        <?php apply_filters('get_desired_font_style', []); ?>
+        <?php $fontStyles = apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -96,7 +96,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div style="border-radius:0 0 15px 15px; background-color:<?php echo esc_attr($data['bg-color']['email_bg_color']); ?>; color:<?php echo esc_attr($data['bg-color']['email_text_color']); ?>;" ><!--[if mso | IE]>
+    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="border-radius:15px 15px 15px 15px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>" ><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            >
         <tr>
@@ -287,7 +287,7 @@
                                                                             <tr>
                                                                                 <td align="left"
                                                                                     style="font-size:0px;padding:10px 25px;padding-right:20px;word-break:break-word;">
-                                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
+                                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
                                                                                         {body}
                                                                                     </div>
                                                                                 </td>
@@ -307,14 +307,14 @@
                                                         width="100%">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="border:3px solid <?php echo esc_attr($data['bg-color']['button_border_color']); ?>;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
+                                                                <td style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
                                                                     <table border="0" cellpadding="0" cellspacing="0"
                                                                         role="presentation" width="100%">
                                                                         <tbody>
                                                                             <tr>
                                                                                 <td align="center"
                                                                                     style="font-size:0px;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:<?php echo esc_attr($data['bg-color']['email_text_color']);?>;">
+                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;">
                                                                                         {discount_code}<span style="font-size:14px;"><br></span>
                                                                                     </div>
                                                                                 </td>
@@ -322,7 +322,7 @@
                                                                             <tr>
                                                                                 <td align="center"
                                                                                     style="font-size:0px;padding:2px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:<?php echo esc_attr($data['bg-color']['email_text_color']);?>;;">
+                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;">
                                                                                         Discount expires :{discount_expires}
                                                                                     </div>
                                                                                 </td>
@@ -373,9 +373,9 @@
                                                     style="border-collapse:separate;line-height:100%;">
                                                     <tr>
                                                         <td align="center" bgcolor="#2B071C" role="presentation"
-                                                            style="border:3px solid <?php echo esc_attr($data['bg-color']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
+                                                            style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
                                                             valign="middle">
-                                                            <p style="display:inline-block;background:<?php echo esc_attr($data['bg-color']['button_bg_color']); ?>;color:<?php echo esc_attr($data['bg-color']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
+                                                            <p style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
                                                                 {button_text}
                                                             </p>
                                                         </td>

--- a/Core/Emails/views/photo-request.php
+++ b/Core/Emails/views/photo-request.php
@@ -7,111 +7,113 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
-        #outlook a {
-            padding: 0;
-        }
+        <?php $fontStyles = apply_filters('get_desired_font_style', []); ?>
+       #outlook a {
+           padding: 0;
+       }
 
-        body {
-            margin: 0;
-            padding: 0;
-            -webkit-text-size-adjust: 100%;
-            -ms-text-size-adjust: 100%;
-        }
+       body {
+           margin: 0;
+           padding: 0;
+           -webkit-text-size-adjust: 100%;
+           -ms-text-size-adjust: 100%
+       }
 
-        table,
-        td {
-            border-collapse: collapse;
-            mso-table-lspace: 0pt;
-            mso-table-rspace: 0pt;
-        }
+       table,
+       td {
+           border-collapse: collapse;
+           mso-table-lspace: 0pt;
+           mso-table-rspace: 0pt;
+       }
 
-        img {
-            border: 0;
-            height: auto;
-            line-height: 100%;
-            outline: none;
-            text-decoration: none;
-            -ms-interpolation-mode: bicubic;
-        }
+       img {
+           border: 0;
+           height: auto;
+           line-height: 100%;
+           outline: none;
+           text-decoration: none;
+           -ms-interpolation-mode: bicubic;
+       }
 
-        p {
-            display: block;
-            margin: 13px 0;
-        }
-    </style>
-    <!--[if mso]>
-    <noscript>
-        <xml>
-            <o:OfficeDocumentSettings>
-                <o:AllowPNG/>
-                <o:PixelsPerInch>96</o:PixelsPerInch>
-            </o:OfficeDocumentSettings>
-        </xml>
-    </noscript>
-    <![endif]--><!--[if lte mso 11]>
-    <style type="text/css">
-        .mj-outlook-group-fix {
-            width: 100% !important;
-        }
-    </style>
-    <![endif]-->
-    <style type="text/css">
-        @media only screen and (min-width: 480px) {
-            .mj-column-per-100 {
-                width: 100% !important;
-                max-width: 100%;
-            }
-        }
-    </style>
-    <style media="screen and (min-width:480px)">
-        .moz-text-html .mj-column-per-100 {
-            width: 100% !important;
-            max-width: 100%;
-        }
-    </style>
-    <style type="text/css">
-        @media only screen and (max-width: 480px) {
-            table.mj-full-width-mobile {
-                width: 100% !important;
-            }
+       p {
+           display: block;
+           margin: 13px 0;
+       }
+   </style>
+   <!--[if mso]>
+   <noscript>
+       <xml>
+           <o:OfficeDocumentSettings>
+               <o:AllowPNG/>
+               <o:PixelsPerInch>96</o:PixelsPerInch>
+           </o:OfficeDocumentSettings>
+       </xml>
+   </noscript>
+   <![endif]--><!--[if lte mso 11]>
+   <style type="text/css">
+       .mj-outlook-group-fix {
+           width: 100% !important;
+       }
+   </style>
+   <![endif]-->
+   <style type="text/css">
+       @media only screen and (min-width: 480px) {
+           .mj-column-per-100 {
+               width: 100% !important;
+               max-width: 100%;
+           }
+       }
+   </style>
+   <style media="screen and (min-width:480px)">
+       .moz-text-html .mj-column-per-100 {
+           width: 100% !important;
+           max-width: 100%;
+       }
+   </style>
+   <style type="text/css">
+       @media only screen and (max-width: 480px) {
+           table.mj-full-width-mobile {
+               width: 100% !important;
+           }
 
-            td.mj-full-width-mobile {
-                width: auto !important;
-            }
-        }
-    </style>
+           td.mj-full-width-mobile {
+               width: auto !important;
+           }
+       }
+   </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#ffffff;">
-    <div style="background-color:#ffffff;">
-        <!--[if mso | IE]>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-    <![endif]-->
-        <div style="margin:20px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
-                            <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr></tr>
-                    </table>
-                    <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
-    </td>
-    </tr>
-    </table>
-    <![endif]-->
+<body savs style="word-spacing:normal;" class="<?php echo esc_attr($fontStyles[0]['class']); ?>">
+   <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+       <!--[if mso | IE]>
+   <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
+       <tr>
+           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+   <![endif]-->
+       <div style="margin:20px auto;max-width:600px;">
+           <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+               <tbody>
+                   <tr>
+                       <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
+                           <!--[if mso | IE]>
+                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                       <tr></tr>
+                   </table>
+                   <![endif]-->
+                       </td>
+                   </tr>
+               </tbody>
+           </table>
+       </div>
+       <!--[if mso | IE]>
+   </td>
+   </tr>
+   </table>
+   <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
+       <?php if ($brandSettings->isLogoEnabled()) { ?>
             <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
@@ -168,12 +170,12 @@
            bgcolor="#ffffff">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
+        <div style="margin:0px auto;max-width:600px;">
+            <table  align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                style="width:100%;">
                 <tbody>
                     <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                        <td style="direction:ltr;font-size:0px;text-align:center;">
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
@@ -182,20 +184,20 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
+                                       style="" width="NaN" bgcolor="#fadfdb">
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
+                                <div style="background:;background-color:;margin:0px auto;border-radius:15px 15px 0 0;max-width:;">
                                     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
+                                        style="background:;background-color:;width:100%;border-radius:15px 15px 0 0;">
                                         <tbody>
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                                                <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
                                                     <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                            <td class="" style="vertical-align:top;"><![endif]-->
                                                     <div class="mj-column-per-100 mj-outlook-group-fix"
                                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
@@ -236,16 +238,16 @@
                                 width="NaN" bgcolor="#fadfdb">
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
+                            <div style="margin:0px auto;border-radius:0 0 15px 15px;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
+                                    style="width:100%;border-radius:0 0 15px 15px;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
                                                 <!--[if mso | IE]>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                                <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-100 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
@@ -254,7 +256,7 @@
                                                             <tr>
                                                                 <td align="left"
                                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
+                                                                    <div style="font-size:16px;line-height:1.5;text-align:left;">
                                                                         {body}
                                                                     </div>
                                                                 </td>
@@ -262,7 +264,7 @@
                                                             <tr>
                                                                 <td align="left"
                                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
+                                                                    <div style="font-size:16px;line-height:1.5;text-align:left;">
                                                                         {discount_text}
                                                                     </div>
                                                                 </td>
@@ -276,10 +278,10 @@
                                                                         <tr>
                                                                             <td align="center" bgcolor="#7c1b06" role="presentation"
                                                                                 href="{review_link}"
-                                                                                style="border:4px solid #ab5959;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#7c1b06;"
+                                                                                style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
                                                                                 <p
-                                                                                    style="display:inline-block;background:#7c1b06;color:#ffffff;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                                    style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
                                                                                     {button_text}
                                                                                 </p>
                                                                             </td>
@@ -312,16 +314,16 @@
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
+                            <div style="background:;background-color:;margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
+                                    style="background:;background-color:;width:100%;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
                                                 <!--[if mso | IE]>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                                <td class="" style="vertical-align:top;"><![endif]-->
                                                 <div class="mj-column-per-100 mj-outlook-group-fix"
                                                     style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                     <?php if ($generalSettings->isFooterEnabled()): ?>
@@ -344,7 +346,7 @@
                                                                 <tr>
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
+                                                                        <div style="font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
                                                                             <p>{footer_text}</p>
                                                                             <a
                                                                                 data-cke-saved-href="http://localhost:7000"

--- a/Core/Emails/views/photo-request.php
+++ b/Core/Emails/views/photo-request.php
@@ -86,7 +86,7 @@
 </head>
 
 <body savs style="word-spacing:normal;" class="<?php echo esc_attr($fontStyles[0]['class']); ?>">
-   <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+   <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
        <!--[if mso | IE]>
    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
        <tr>

--- a/Core/Emails/views/photo-request.php
+++ b/Core/Emails/views/photo-request.php
@@ -167,7 +167,7 @@
 
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#ffffff">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:0px auto;max-width:600px;">
@@ -184,7 +184,7 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="" width="NaN" bgcolor="#fadfdb">
+                                       style="" >
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
@@ -235,7 +235,7 @@
                             <!--[if mso | IE]>
                         <td class="" style="">
                             <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
+                                >
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                             <div style="margin:0px auto;border-radius:0 0 15px 15px;">
@@ -276,7 +276,7 @@
                                                                         role="presentation"
                                                                         style="border-collapse:separate;line-height:100%;">
                                                                         <tr>
-                                                                            <td align="center" bgcolor="#7c1b06" role="presentation"
+                                                                            <td align="center"  role="presentation"
                                                                                 href="{review_link}"
                                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
@@ -310,7 +310,7 @@
                             <!--[if mso | IE]>
                         <td class="" style="">
                             <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
+                                >
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
@@ -334,8 +334,8 @@
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                                                         <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
@@ -346,12 +346,12 @@
                                                                 <tr>
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
+                                                                        <div style="font-size:14px;line-height:1;text-align:center;">
                                                                             <p>{footer_text}</p>
                                                                             <a
                                                                                 data-cke-saved-href="http://localhost:7000"
                                                                                 href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
                                                                         </div>
                                                                     </td>
                                                                 </tr>

--- a/Core/Emails/views/plain/discount-notify.php
+++ b/Core/Emails/views/plain/discount-notify.php
@@ -1,13 +1,15 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title></title><!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -83,300 +85,300 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#ffffff;">
-    <div style="background-color:#ffffff;">
-        <!--[if mso | IE]>
+<body style="word-spacing:normal;">
+<div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="border:; border-radius: 15px 15px 15px 15px ;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:20px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:20px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
                     </table>
                     <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isLogoEnabled()) { ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                <td style="width:50px;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="50" alt="">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table><![endif]-->
-        <?php } ?>
+    <?php } ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#ffffff">
+    >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                        <![endif]-->
-                            <?php if ($brandSettings->isEmailBannerEnabled()): ?>
-                                <!--[if mso | IE]>
-                            <td class="" style="">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
-                                    <tr>
-                                        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
-                                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
-                                        <tbody>
+                    <?php if ($brandSettings->isEmailBannerEnabled()): ?>
+                        <!--[if mso | IE]>
+                        <td class="" style="">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
+                                   style="" >
+                                <tr>
+                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                        <![endif]-->
+                        <div style="margin:0px auto;border-radius:15px 15px 0 0;">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="width:100%;border-radius:15px 15px 0 0;">
+                                <tbody>
+                                <tr>
+                                    <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
+                                        <!--[if mso | IE]>
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                                                    <!--[if mso | IE]>
-                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                        <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
+                                                <td class="" style="vertical-align:top;"><![endif]-->
+                                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                   style="vertical-align:top;" width="100%">
+                                                <tbody>
+                                                <tr>
+                                                    <td align="center"
+                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
+                                                        <table border="0" cellpadding="0" cellspacing="0"
+                                                               role="presentation"
+                                                               style="border-collapse:collapse;border-spacing:0px;">
                                                             <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
-                                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                                            role="presentation"
-                                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                                            <tbody>
-                                                                                <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="{banner_src}"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
-                                                                                </tr>
-                                                                            </tbody>
-                                                                        </table>
-                                                                    </td>
-                                                                </tr>
+                                                            <tr>
+                                                                <td style="width:100%;"><img height="auto"
+                                                                                             src="{banner_src}"
+                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                                             width="100%"></td>
+                                                            </tr>
                                                             </tbody>
                                                         </table>
-                                                    </div>
-                                                    <!--[if mso | IE]></td></tr></table><![endif]-->
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table></td><![endif]-->
-                            <?php endif; ?>
-
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
-                                <tr>
-                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
-                                    <tbody>
-                                        <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="vertical-align:top;" width="100%">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td align="left"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
-                                                                        {body}
-                                                                    </div>
-                                                                </td>
-                                                            </tr>
-                                                            <tr>
-                                                                <td align="center" vertical-align="middle"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                                        role="presentation"
-                                                                        style="border-collapse:separate;line-height:100%;">
-                                                                        <tr>
-                                                                            <td align="center" bgcolor="#7c1b06" role="presentation"
-                                                                                href="{shop_page_url}"
-                                                                                style="border:4px solid #ab5959;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#7c1b06;"
-                                                                                valign="middle">
-                                                                                <p
-                                                                                    style="display:inline-block;background:#7c1b06;color:#ffffff;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
-                                                                                    {discount_code}
-                                                                                </p>
-                                                                            </td>
-                                                                        </tr>
-                                                                    </table>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </div>
-                                                <!--[if mso | IE]></td>
-                                            </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                        <!--[if mso | IE]></td></tr></table><![endif]-->
                                     </td>
                                 </tr>
+                                </tbody>
                             </table>
-                        </td>
-<![endif]-->
-                            <?php if ($generalSettings->isFooterEnabled()) ?>
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
-                                <tr>
-<td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-<![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
-                                    <tbody>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table></td><![endif]-->
+                    <?php endif; ?>
+
+                    <!--[if mso | IE]>
+                    <td class="" style="">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style=""
+                        >
+                            <tr>
+                                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                    <div style="margin:0px auto;border-radius:0 0 15px 15px;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;border-radius:0 0 15px 15px;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <?php if ($generalSettings->isFooterEnabled()): ?>
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                <td align="left"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
+                                                        {body}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center" vertical-align="middle"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation"
+                                                           style="border-collapse:separate;line-height:100%;">
+                                                        <tr>
+                                                            <td align="center"  role="presentation"
+                                                                href="{shop_page_url}"
+                                                                style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
+                                                                valign="middle">
+                                                                <p
+                                                                        style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                    {discount_code}
+                                                                </p>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]></td>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]>
+                    </td>
+                    </tr>
+                    </table>
+                    </td>
+                    <![endif]-->
+                    <?php if ($generalSettings->isFooterEnabled()) ?>
+                <!--[if mso | IE]>
+                <td class="" style="">
+                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style=""
+                    >
+                        <tr>
+                            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                <![endif]-->
+                    <div style="margin:0px auto;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                        <tr>
+                                            <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <?php if ($generalSettings->isFooterEnabled()): ?>
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <p
+                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;" role="presentation" >
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
                                                         </tr>
                                                     </table><![endif]-->
-                                                                    </td>
-                                                                </tr>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
-                                                                            <p>{footer_text}</p>
-                                                                            <a
-                                                                                data-cke-saved-href="http://localhost:7000"
-                                                                                href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                </div>
-                                                <!--[if mso | IE]>
                                                 </td>
                                             </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
+                                            <tr>
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
+                                                        <p>{footer_text}</p>
+                                                        <a
+                                                                data-cke-saved-href="http://localhost:7000"
+                                                                href="#"
+                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]>
                                     </td>
-                                </tr>
-                            </table>
-                        </td>
-                    <![endif]-->
-                        <?php endif; ?>
-                        <!--[if mso | IE]>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                <!--[if mso | IE]>
+                </td>
+                </tr>
+                </table>
+                </td>
+                <![endif]-->
+                <?php endif; ?>
+                    <!--[if mso | IE]>
                     </tr>
-            </table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]></td>
+                    </table><![endif]-->
+                </td>
             </tr>
-</table>
-<![endif]-->
+            </tbody>
+        </table>
     </div>
+    <!--[if mso | IE]></td>
+    </tr>
+    </table>
+    <![endif]-->
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/discount-reminder.php
+++ b/Core/Emails/views/plain/discount-reminder.php
@@ -1,13 +1,15 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title></title><!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -93,351 +95,351 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#EDE4E7;">
-    <div style="background-color:#EDE4E7;"><!--[if mso | IE]>
+<body style="word-spacing:normal;">
+<div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="border-radius:15px 15px 15px 15px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>" ><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+    >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($brandSettings->isLogoEnabled()): ?>
-            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td style="vertical-align:top;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                                                        <tbody></tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]></td></tr></table>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#EDE4E7">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-            <div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:45px;"><img height="auto"
-                                                                        src="https://static.flycart.net/email_customizer_advance/image/add-ons/eca-yith-woocommerce-request-a-quote-premium/icons/email-with-quote.png"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="45"></td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        <?php endif; ?>
-        <!--[if mso | IE]></td></tr></table>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($brandSettings->isEmailBannerEnabled()): ?>
-            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;border-radius:15px 15px 0 0;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;border-radius:15px 15px 0 0;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:4px;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:592px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:215px;"><img height="auto"
-                                                                        src="https://static.flycart.net/email_customizer_advance/image/editor/logo.png"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="215"></td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        <?php endif; ?>
-        <!--[if mso | IE]></td></tr></table>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#FFFFFF">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+    <?php if ($brandSettings->isLogoEnabled()): ?>
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+                   style="width:100%;">
                 <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                            <!--[if mso | IE]>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td style="vertical-align:top;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                                            <tbody></tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]></td></tr></table>
+        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+        >
+            <tr>
+                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
+                                            <tr>
+                                                <td style="width:45px;"><img height="auto"
+                                                                             src="https://static.flycart.net/email_customizer_advance/image/add-ons/eca-yith-woocommerce-request-a-quote-premium/icons/email-with-quote.png"
+                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                             width="45"></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+    <!--[if mso | IE]></td></tr></table>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+    >
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <?php if ($brandSettings->isEmailBannerEnabled()): ?>
+        <div style="margin:0px auto;border-radius:15px 15px 0 0;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;border-radius:15px 15px 0 0;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:4px;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px;text-align:center;">
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="" style="vertical-align:top;width:592px;"><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
+                                            <tr>
+                                                <td style="width:215px;"><img height="auto"
+                                                                              src="https://static.flycart.net/email_customizer_advance/image/editor/logo.png"
+                                                                              style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                              width="215"></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+    <!--[if mso | IE]></td></tr></table>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+    >
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#FADFDB">
+                                       style= "" >
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                            <div style="background:#FADFDB;background-color:#FADFDB;margin:0px auto;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#FADFDB;background-color:#FADFDB;width:100%;">
-                                    <tbody>
-                                        <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                                                <!--[if mso | IE]>
+                    <div style="margin:0px auto;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
+                                    <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr></tr>
                                     </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]></td></tr></table></td>
-                <td class="" style="">
-                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                           width="NaN" bgcolor="#F5CEE4">
-                        <tr>
-                            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
-                                    <tbody>
-                                        <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td></tr></table></td>
+                    <td class="" style="">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
+                        >
+                            <tr>
+                                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                    <div style="margin:0px auto;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        width="100%">
+                                            <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td style="vertical-align:top;padding:25px;padding-top:25px;padding-right:25px;padding-bottom:25px;padding-left:25px;">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation" width="100%">
                                                         <tbody>
-                                                            <tr>
-                                                                <td style="background-color:#F5CEE4;vertical-align:top;padding:25px;padding-top:25px;padding-right:25px;padding-bottom:25px;padding-left:25px;">
-                                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                                        role="presentation" width="100%">
-                                                                        <tbody>
-                                                                            <tr>
-                                                                                <td align="left"
-                                                                                    style="font-size:0px;padding:10px 25px;padding-right:20px;word-break:break-word;">
-                                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
-                                                                                        {body}
-                                                                                    </div>
-                                                                                </td>
-                                                                            </tr>
-                                                                        </tbody>
-                                                                    </table>
-                                                                </td>
-                                                            </tr>
+                                                        <tr>
+                                                            <td align="left"
+                                                                style="font-size:0px;padding:10px 25px;padding-right:20px;word-break:break-word;">
+                                                                <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
+                                                                    {body}
+                                                                </div>
+                                                            </td>
+                                                        </tr>
                                                         </tbody>
                                                     </table>
-                                                </div>
-                                                <!--[if mso | IE]></td>
-                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-70 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        width="100%">
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]></td>
+                                    <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-70 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation" width="100%">
                                                         <tbody>
-                                                            <tr>
-                                                                <td style="border:3px solid #E3E3E3;vertical-align:top;padding:18px;padding-top:18px;padding-right:18px;padding-bottom:18px;padding-left:18px;">
-                                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                                        role="presentation" width="100%">
-                                                                        <tbody>
-                                                                            <tr>
-                                                                                <td align="center"
-                                                                                    style="font-size:0px;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:#000000;">
-                                                                                        {discount_code}<span style="font-size:14px;"><br></span>
-                                                                                    </div>
-                                                                                </td>
-                                                                            </tr>
-                                                                            <tr>
-                                                                                <td align="center"
-                                                                                    style="font-size:0px;padding:2px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px;word-break:break-word;">
-                                                                                    <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;color:#000000;">
-                                                                                        Discount expires :{discount_expires}
-                                                                                    </div>
-                                                                                </td>
-                                                                            </tr>
-                                                                        </tbody>
-                                                                    </table>
-                                                                </td>
-                                                            </tr>
+                                                        <tr>
+                                                            <td align="center"
+                                                                style="font-size:0px;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;word-break:break-word;">
+                                                                <div style="font-family:Times New Roman, Times, serif;font-size:39px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;">
+                                                                    {discount_code}<span style="font-size:14px;"><br></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td align="center"
+                                                                style="font-size:0px;padding:2px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px;word-break:break-word;">
+                                                                <div style="font-family:Times New Roman, Times, serif;font-size:13px;font-style:normal;font-weight:600;line-height:1.5;text-align:center;">
+                                                                    Discount expires :{discount_expires}
+                                                                </div>
+                                                            </td>
+                                                        </tr>
                                                         </tbody>
                                                     </table>
-                                                </div>
-                                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]></td></tr></table>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#F5CEE4;background-color:#F5CEE4;margin:0px auto;border-radius:0 0 15px 15px;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#F5CEE4;background-color:#F5CEE4;width:100%;border-radius:0 0 15px 15px;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                            <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                            <div class="mj-column-per-100 mj-outlook-group-fix"
-                                style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="vertical-align:top;" width="100%">
-                                    <tbody>
-                                        <tr>
-                                            <td align="center" vertical-align="middle"
-                                                style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                    style="border-collapse:separate;line-height:100%;">
-                                                    <tr>
-                                                        <td align="center" bgcolor="#2B071C" role="presentation"
-                                                            style="border:3px solid #E86F96;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;background:#2B071C;"
-                                                            valign="middle">
-                                                            <p style="display:inline-block;background:#2B071C;color:#ffffff;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
-                                                                {button_text}
-                                                            </p>
-                                                        </td>
-                                                    </tr>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]></td></tr></table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]></td></tr></table>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#EDE4E7">
-        <tr>
-            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($generalSettings->isFooterEnabled()): ?><div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <p
-                                                        style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
-</td></tr></table><![endif]-->
                                                 </td>
                                             </tr>
-                                            <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
-                                                        {footer_text}<br><br>
-                                                        <a
-                                                            data-cke-saved-href="http://localhost:7000" href="http://localhost:7000"
-                                                            style="color:#c2c2c2;">Unsubscribe</a><br>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div><?php endif; ?>
-        <!--[if mso | IE]></td></tr></table><![endif]-->
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
     </div>
+    <!--[if mso | IE]></td></tr></table>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+    >
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;border-radius:0 0 15px 15px;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center" vertical-align="middle"
+                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                           style="border-collapse:separate;line-height:100%;">
+                                        <tr>
+                                            <td align="center"  role="presentation"
+                                                style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
+                                                valign="middle">
+                                                <p style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-family:Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;border-radius:3px;">
+                                                    {button_text}
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+    >
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <?php if ($generalSettings->isFooterEnabled()): ?><div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <p
+                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
+                                        {footer_text}<br><br>
+                                        <a
+                                                data-cke-saved-href="http://localhost:7000" href="http://localhost:7000"
+                                                style="">Unsubscribe</a><br>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div><?php endif; ?>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/photo-request.php
+++ b/Core/Emails/views/plain/photo-request.php
@@ -1,13 +1,15 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title></title><!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -16,7 +18,7 @@
             margin: 0;
             padding: 0;
             -webkit-text-size-adjust: 100%;
-            -ms-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%
         }
 
         table,
@@ -83,308 +85,308 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#ffffff;">
-    <div style="background-color:#ffffff;">
-        <!--[if mso | IE]>
+<body savs style="word-spacing:normal;" class="<?php echo esc_attr($fontStyles[0]['class']); ?>">
+<div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:20px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:20px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
                     </table>
                     <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isLogoEnabled()) { ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                <td style="width:50px;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="50" alt="">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table><![endif]-->
-        <?php } ?>
+    <?php } ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#ffffff">
+    >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table  align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                        <![endif]-->
-                            <?php if ($brandSettings->isEmailBannerEnabled()): ?>
-                                <!--[if mso | IE]>
-                            <td class="" style="">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
-                                    <tr>
-                                        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
-                                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
-                                        <tbody>
+                    <?php if ($brandSettings->isEmailBannerEnabled()): ?>
+                        <!--[if mso | IE]>
+                        <td class="" style="">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
+                                   style="" >
+                                <tr>
+                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                        <![endif]-->
+                        <div style="background:;background-color:;margin:0px auto;border-radius:15px 15px 0 0;max-width:;">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="background:;background-color:;width:100%;border-radius:15px 15px 0 0;">
+                                <tbody>
+                                <tr>
+                                    <td style="direction:ltr;font-size:0px;padding-bottom:0px;text-align:center;">
+                                        <!--[if mso | IE]>
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                                                    <!--[if mso | IE]>
-                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                        <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
+                                                <td class="" style="vertical-align:top;"><![endif]-->
+                                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                   style="vertical-align:top;" width="100%">
+                                                <tbody>
+                                                <tr>
+                                                    <td align="center"
+                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
+                                                        <table border="0" cellpadding="0" cellspacing="0"
+                                                               role="presentation"
+                                                               style="border-collapse:collapse;border-spacing:0px;">
                                                             <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
-                                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                                            role="presentation"
-                                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                                            <tbody>
-                                                                                <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="{banner_src}"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
-                                                                                </tr>
-                                                                            </tbody>
-                                                                        </table>
-                                                                    </td>
-                                                                </tr>
+                                                            <tr>
+                                                                <td style="width:100%;"><img height="auto"
+                                                                                             src="{banner_src}"
+                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                                             width="100%"></td>
+                                                            </tr>
                                                             </tbody>
                                                         </table>
-                                                    </div>
-                                                    <!--[if mso | IE]></td></tr></table><![endif]-->
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table></td><![endif]-->
-                            <?php endif; ?>
-
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
-                                <tr>
-                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
-                                    <tbody>
-                                        <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="vertical-align:top;" width="100%">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td align="left"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
-                                                                        {body}
-                                                                    </div>
-                                                                </td>
-                                                            </tr>
-                                                            <tr>
-                                                                <td align="left"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
-                                                                        {discount_text}
-                                                                    </div>
-                                                                </td>
-                                                            </tr>
-                                                            <tr>
-                                                                <td align="center" vertical-align="middle"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <table border="0" cellpadding="0" cellspacing="0"
-                                                                        role="presentation"
-                                                                        style="border-collapse:separate;line-height:100%;">
-                                                                        <tr>
-                                                                            <td align="center" bgcolor="#7c1b06" role="presentation"
-                                                                                href="{review_link}"
-                                                                                style="border:4px solid #ab5959;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#7c1b06;"
-                                                                                valign="middle">
-                                                                                <p
-                                                                                    style="display:inline-block;background:#7c1b06;color:#ffffff;font-family:Helvetica, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
-                                                                                    {button_text}
-                                                                                </p>
-                                                                            </td>
-                                                                        </tr>
-                                                                    </table>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </div>
-                                                <!--[if mso | IE]></td>
-                                            </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                        <!--[if mso | IE]></td></tr></table><![endif]-->
                                     </td>
                                 </tr>
+                                </tbody>
                             </table>
-                        </td>
-<![endif]-->
-                            <?php if ($generalSettings->isFooterEnabled()) ?>
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
-                                <tr>
-<td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-<![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
-                                    <tbody>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table></td><![endif]-->
+                    <?php endif; ?>
+
+                    <!--[if mso | IE]>
+                    <td class="" style="">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
+                        >
+                            <tr>
+                                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                    <div style="margin:0px auto;border-radius:0 0 15px 15px;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;border-radius:0 0 15px 15px;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <?php if ($generalSettings->isFooterEnabled()): ?>
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                <td align="left"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-size:16px;line-height:1.5;text-align:left;">
+                                                        {body}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="left"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-size:16px;line-height:1.5;text-align:left;">
+                                                        {discount_text}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center" vertical-align="middle"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation"
+                                                           style="border-collapse:separate;line-height:100%;">
+                                                        <tr>
+                                                            <td align="center"  role="presentation"
+                                                                href="{review_link}"
+                                                                style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
+                                                                valign="middle">
+                                                                <p
+                                                                        style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                    {button_text}
+                                                                </p>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]></td>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]>
+                    </td>
+                    </tr>
+                    </table>
+                    </td>
+                    <![endif]-->
+                    <?php if ($generalSettings->isFooterEnabled()) ?>
+                <!--[if mso | IE]>
+                <td class="" style="">
+                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
+                    >
+                        <tr>
+                            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                <![endif]-->
+                    <div style="background:;background-color:;margin:0px auto;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:;background-color:;width:100%;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                        <tr>
+                                            <td class="" style="vertical-align:top;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <?php if ($generalSettings->isFooterEnabled()): ?>
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <p
+                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
                                                         </tr>
                                                     </table><![endif]-->
-                                                                    </td>
-                                                                </tr>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
-                                                                            <p>{footer_text}</p>
-                                                                            <a
-                                                                                data-cke-saved-href="http://localhost:7000"
-                                                                                href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                </div>
-                                                <!--[if mso | IE]>
                                                 </td>
                                             </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
+                                            <tr>
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-size:14px;line-height:1;text-align:center;">
+                                                        <p>{footer_text}</p>
+                                                        <a
+                                                                data-cke-saved-href="http://localhost:7000"
+                                                                href="#"
+                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]>
                                     </td>
-                                </tr>
-                            </table>
-                        </td>
-                    <![endif]-->
-                        <?php endif; ?>
-                        <!--[if mso | IE]>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                <!--[if mso | IE]>
+                </td>
+                </tr>
+                </table>
+                </td>
+                <![endif]-->
+                <?php endif; ?>
+                    <!--[if mso | IE]>
                     </tr>
-            </table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]></td>
+                    </table><![endif]-->
+                </td>
             </tr>
-</table>
-<![endif]-->
+            </tbody>
+        </table>
     </div>
+    <!--[if mso | IE]></td>
+    </tr>
+    </table>
+    <![endif]-->
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/review-reminder.php
+++ b/Core/Emails/views/plain/review-reminder.php
@@ -1,6 +1,6 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title>
@@ -10,7 +10,9 @@
     <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php  $fontStyles = apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -103,143 +105,142 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:<?php
-                                                    echo $brandSettings->getEmailBgColor() ?>;color: <?php echo $brandSettings->getTextColor() ?>">
-    <div>
-        <!--[if mso | IE]>
+<body style="word-spacing:normal;">
+<div  class= "<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>; border;; border-radius:15px 15px 15px 15px; <?php echo esc_attr($fontStyles['content']); ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
                     </table>
                     <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isLogoEnabled()) { ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                <td style="width:50px;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="50" alt="">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table><![endif]-->
-        <?php } ?>
+    <?php } ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
            style="width:600px; background-color: <?php echo $brandSettings->getContentBgColor() ?>;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%; background-color: <?php echo $brandSettings->getContentBgColor() ?>;">
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
+                                           style="border-collapse:collapse;border-spacing:0px;">
                                         <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{banner_src}"
-                                                                        alt=""
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
+                                        <tr>
+                                            <td style="width:50px;">
+                                                <img height="auto"
+                                                     src="{banner_src}"
+                                                     alt=""
+                                                     style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
+                                            </td>
+                                        </tr>
                                         </tbody>
                                     </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+<!--[if mso | IE]>
     </td>
     </tr>
     </table>
@@ -252,246 +253,246 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
             <![endif]-->
-            <div style="background-color:<?php echo $brandSettings->getContentBgColor() ?>;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                     <!--[if mso | IE]>
-                    <td class="" style="vertical-align:top;width:600px;">
-                    <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="left"
-                                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
-                                                    <div style="font-family:Arial, sans-serif;font-size:14px;line-height:28px;text-align:left;">
-                                                        {body}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+            <tr>
+        <!--[if mso | IE]>
+        <td class="" style="vertical-align:top;width:600px;">
+        <![endif]-->
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="left"
+                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
+                                    <div style="font-family:Arial, sans-serif;font-size:14px;line-height:28px;text-align:left;">
+                                        {body}
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
 
-            <?php foreach ($order->get_items() as $line_item) { ?>
-                <?php
-                $product_id = $line_item['product_id'];
-                $product = wc_get_product($product_id);
-                $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
-                ?>
-                <!--[if mso | IE]>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
-    <tr bgcolor="<?php echo $brandSettings->getContentBgColor() ?>">
-    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-   <![endif]-->
-                <div style="margin:0px auto;max-width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>">
-                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="width:100%;">
-                        <tbody>
-                            <tr>
-                                <td style="direction:ltr;font-size:0px;padding:20px 0px 20px 0px;text-align:center;">
-                                    <!--[if mso | IE]>
+    <?php foreach ($order->get_items() as $line_item) { ?>
+        <?php
+        $product_id = $line_item['product_id'];
+        $product = wc_get_product($product_id);
+        $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
+        ?>
+        <!--[if mso | IE]>
+        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
+            <tr bgcolor="">
+                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+        <![endif]-->
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0px 20px 0px;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                         <![endif]-->
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:600px;">
                         <![endif]-->
-                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td style="width:128px;">
-                                                                        <img height="auto"
-                                                                            alt="Image"
-                                                                            src="<?php echo $product->get_image(); ?>"
-                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                            width="128">
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                    </td>
-                                                </tr>
+                                            <tr>
+                                                <td style="width:128px;">
+                                                    <img height="auto"
+                                                         alt="Image"
+                                                         src="<?php echo $product->get_image(); ?>"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="128">
+                                                </td>
+                                            </tr>
                                             </tbody>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]></td><![endif]-->
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td><![endif]-->
 
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                                    <div class="mj-column-per-25 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
-                                            <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
-                                                            <?php echo $line_item->get_name() ?>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td align="center" vertical-align="middle"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:separate;line-height:100%;">
-                                                            <tr>
-                                                                <td align="center"
-                                                                    role="presentation"
-                                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
-                                                                    valign="middle">
-                                                                    <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo $brandSettings->getButtonBgColor() ?>;color:<?php echo $brandSettings->getButtonTextColor() ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo $brandSettings->getButtonBorderColor() ?>"
-                                                                        target="_blank">{button_text}
-                                                                    </a>
-                                                                </td>
-                                                            </tr>
-                                                        </table>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
+                        <div class="mj-column-per-25 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
+                                            <?php echo $line_item->get_name() ?>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" vertical-align="middle"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:separate;line-height:100%;">
+                                            <tr>
+                                                <td align="center"
+                                                    role="presentation"
+                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
+                                                    valign="middle">
+                                                    <a href="<?php echo $reviewLink ?>"
+                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['button_text_color']); ?>; border:;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']); ?>;"
+                                                       target="_blank">{button_text}
+                                                    </a>
+                                                </td>
+                                            </tr>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]>
                         </td>
                         <![endif]-->
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         </tr>
                         </table>
                         <![endif]-->
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <!--[if mso | IE]>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table>
         <![endif]-->
-            <?php } ?>
+    <?php } ?>
 
-            <!--[if mso | IE]>
+    <!--[if mso | IE]>
 <?php if ($generalSettings->isFooterEnabled()): ?>
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="width:600px;"
            width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;">
                     <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>;">
-                                                        {footer_text}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>">
-                                                        <a href="{unsubscribe_link}">Unsubscribe</a>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
+                                        {footer_text}
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;">
+                                        <a href="{unsubscribe_link}">Unsubscribe</a>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+<!--[if mso | IE]>
 </td>
 </tr>
 </table>
 <![endif]-->
-        <?php endif ?>
+<?php endif ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
            style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0"
-                role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0"
+               role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0"
                            cellspacing="0">
                         <tr></tr>
                     </table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
-    </div>
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/review-reply.php
+++ b/Core/Emails/views/plain/review-reply.php
@@ -1,13 +1,15 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title></title><!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -83,295 +85,295 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#EDE4E7;">
-    <div style="background-color:#EDE4E7;">
-        <!--[if mso | IE]>
+<body style="word-spacing:normal;">
+<div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+    >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#F5CEE4;background-color:#F5CEE4;margin:20px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:20px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                            <div class="mj-column-per-100 mj-outlook-group-fix"
-                                style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                                    <tbody>
-                                        <tr>
-                                            <td style="vertical-align:top;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;">
-                                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                                                    <tbody></tbody>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]></td></tr></table><![endif]-->
-                        </td>
-                    </tr>
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                            <tr>
+                                <td style="vertical-align:top;padding:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;">
+                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                                        <tbody></tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
+    </td></tr></table>
+    <![endif]-->
+
+    <?php if ($brandSettings->isLogoEnabled()): ?>
+        <!--[if mso | IE]>
+        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+        >
+            <tr>
+                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
+                                            <tr>
+                                                <td style="width:45px;"><img height="auto"
+                                                                             src="{logo_src}"
+                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                             width="45"></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td>
+                        </tr>
+                        </table><![endif]-->
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>
         <!--[if mso | IE]>
-            </td></tr></table>
-        <![endif]-->
-
-        <?php if ($brandSettings->isLogoEnabled()): ?>
-            <!--[if mso | IE]>
-        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-            bgcolor="#EDE4E7">
-            <tr>
-                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-            <div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                <!--[if mso | IE]>
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                        <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:45px;"><img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="45"></td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
-                        </tr>
-                    </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
-                </td>
-            </tr>
+        </td>
+        </tr>
         </table><![endif]-->
-        <?php endif; ?>
+    <?php endif; ?>
 
-        <!--[if mso | IE]>
-        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-            bgcolor="#FFFFFF">
+    <!--[if mso | IE]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+    >
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
             <tr>
-                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                            <!--[if mso | IE]>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                        <![endif]-->
-                            <?php if ($brandSettings->isEmailBannerEnabled()): ?>
-                                <!--[if mso | IE]>
-                            <td class="" style="">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
-                                    <tr>
-                                        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
-                                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
-                                        <tbody>
+                    <?php if ($brandSettings->isEmailBannerEnabled()): ?>
+                        <!--[if mso | IE]>
+                        <td class="" style="">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
+                                   style="" >
+                                <tr>
+                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                        <![endif]-->
+                        <div style="margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="width:100%;border-radius:15px 15px 0 0;">
+                                <tbody>
+                                <tr>
+                                    <td style="direction:ltr;font-size:0px;text-align:center;">
+                                        <!--[if mso | IE]>
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
-                                                    <!--[if mso | IE]>
+                                                <td class="" style="vertical-align:top;"><![endif]-->
+                                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                                   style="vertical-align:top;" width="100%">
+                                                <tbody>
+                                                <tr>
+                                                    <td align="center"
+                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
+                                                        <table border="0" cellpadding="0" cellspacing="0"
+                                                               role="presentation"
+                                                               style="border-collapse:collapse;border-spacing:0px;">
+                                                            <tbody>
+                                                            <tr>
+                                                                <td style="width:100%;"><img height="auto"
+                                                                                             src="<?php echo $brandSettings->getEmailBanner() ?>"
+                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                                             width="100%"></td>
+                                                            </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table></td><![endif]-->
+                    <?php endif; ?>
+
+                    <!--[if mso | IE]>
+                    <td class="" style="">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
+                        >
+                            <tr>
+                                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                    <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;border-radius:0 0 15px 15px;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
                                             <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px;padding-right:10px;padding-left:10px;word-break:break-word;">
-                                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                                            role="presentation"
-                                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                                            <tbody>
-                                                                                <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="<?php echo $brandSettings->getEmailBanner() ?>"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
-                                                                                </tr>
-                                                                            </tbody>
-                                                                        </table>
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
+                                                        {body}
                                                     </div>
-                                                    <!--[if mso | IE]></td></tr></table><![endif]-->
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table></td><![endif]-->
-                            <?php endif; ?>
-
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
-                                <tr>
-                                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
-                                    <tbody>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]></td>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]>
+                    </td>
+                    </tr>
+                    </table>
+                    </td>
+                    <![endif]-->
+                    <?php if ($generalSettings->isFooterEnabled()) ?>
+                <!--[if mso | IE]>
+                <td class="" style="">
+                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
+                    >
+                        <tr>
+                            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+                <![endif]-->
+                    <div style="margin:0px auto;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="width:100%;">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
+                                    <!--[if mso | IE]>
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                        <?php if ($generalSettings->isFooterEnabled()): ?>
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;" width="100%">
+                                            <tbody>
                                             <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="vertical-align:top;" width="100%">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td align="left"
-                                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
-                                                                        {body}
-                                                                    </div>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </div>
-                                                <!--[if mso | IE]></td>
-                                            </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-<![endif]-->
-                            <?php if ($generalSettings->isFooterEnabled()) ?>
-                            <!--[if mso | IE]>
-                        <td class="" style="">
-                            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
-                                <tr>
-<td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-<![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
-                                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
-                                    <tbody>
-                                        <tr>
-                                            <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
-                                                <!--[if mso | IE]>
-                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
-                                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                                    <?php if ($generalSettings->isFooterEnabled()): ?>
-                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                            style="vertical-align:top;" width="100%">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <p
+                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px 3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
                                                         </tr>
                                                     </table><![endif]-->
-                                                                    </td>
-                                                                </tr>
-                                                                <tr>
-                                                                    <td align="center"
-                                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
-                                                                            <p>{footer_text}</p>
-                                                                            <a
-                                                                                data-cke-saved-href="http://localhost:7000"
-                                                                                href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                </div>
-                                                <!--[if mso | IE]>
                                                 </td>
                                             </tr>
-                                        </table><![endif]-->
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!--[if mso | IE]>
+                                            <tr>
+                                                <td align="center"
+                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                    <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
+                                                        <p>{footer_text}</p>
+                                                        <a
+                                                                data-cke-saved-href="http://localhost:7000"
+                                                                href="#"
+                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!--[if mso | IE]>
                                     </td>
-                                </tr>
-                            </table>
-                        </td>
-                    <![endif]-->
-                        <?php endif; ?>
-                        <!--[if mso | IE]>
+                                    </tr>
+                                    </table><![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                <!--[if mso | IE]>
+                </td>
+                </tr>
+                </table>
+                </td>
+                <![endif]-->
+                <?php endif; ?>
+                    <!--[if mso | IE]>
                     </tr>
-            </table><![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
-            </td>
+                    </table><![endif]-->
+                </td>
             </tr>
-</table>
-<![endif]-->
+            </tbody>
+        </table>
     </div>
+    <!--[if mso | IE]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/review-request.php
+++ b/Core/Emails/views/plain/review-request.php
@@ -1,6 +1,6 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title>
@@ -10,7 +10,9 @@
     <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -103,143 +105,142 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:<?php
-                                                    echo $brandSettings->getEmailBgColor() ?>;color: <?php echo $brandSettings->getTextColor() ?>">
-    <div>
-        <!--[if mso | IE]>
+<body style="word-spacing:normal;">
+<div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
                     </table>
                     <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isLogoEnabled()) { ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                <td style="width:50px;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="50" alt="">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table><![endif]-->
-        <?php } ?>
+    <?php } ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
            style="width:600px; background-color: <?php echo $brandSettings->getContentBgColor() ?>;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%; background-color: <?php echo $brandSettings->getContentBgColor() ?>;">
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%; background-color: <?php echo $brandSettings->getContentBgColor() ?>;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
+                                           style="border-collapse:collapse;border-spacing:0px;">
                                         <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{banner_src}"
-                                                                        alt=""
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
+                                        <tr>
+                                            <td style="width:50px;">
+                                                <img height="auto"
+                                                     src="{banner_src}"
+                                                     alt=""
+                                                     style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
+                                            </td>
+                                        </tr>
                                         </tbody>
                                     </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+<!--[if mso | IE]>
     </td>
     </tr>
     </table>
@@ -252,246 +253,246 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
             <![endif]-->
-            <div style="background-color:<?php echo $brandSettings->getContentBgColor() ?>;margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                        <td class="" style="vertical-align:top;width:600px;">
-                        <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="left"
-                                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
-                                                    <div style="font-family:Arial, sans-serif;font-size:14px;line-height:28px;text-align:left;">
-                                                        {body}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                            <td class="" style="vertical-align:top;width:600px;">
+                    <![endif]-->
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="left"
+                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
+                                    <div style="font-family:Arial, sans-serif;font-size:14px;line-height:28px;text-align:left;">
+                                        {body}
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
 
-            <?php foreach ($order->get_items() as $line_item) { ?>
-                <?php
-                $product_id = $line_item['product_id'];
-                $product = wc_get_product($product_id);
-                $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
-                ?>
-                <!--[if mso | IE]>
+    <?php foreach ($order->get_items() as $line_item) { ?>
+        <?php
+        $product_id = $line_item['product_id'];
+        $product = wc_get_product($product_id);
+        $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
+        ?>
+        <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
-    <tr bgcolor="<?php echo $brandSettings->getContentBgColor() ?>">
+    <tr bgcolor="<?php echo esc_attr($data['styles']['email_bg_color']); ?>">
     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
    <![endif]-->
-                <div style="margin:0px auto;max-width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>">
-                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="width:100%;">
-                        <tbody>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;padding:20px 0px 20px 0px;text-align:center;">
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
-                                <td style="direction:ltr;font-size:0px;padding:20px 0px 20px 0px;text-align:center;">
-                                    <!--[if mso | IE]>
-                                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                    <tr>
-                                <![endif]-->
-                                    <!--[if mso | IE]>
-                                        <td class="" style="vertical-align:top;width:600px;">
-                                <![endif]-->
-                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
+                        <![endif]-->
+                        <!--[if mso | IE]>
+                        <td class="" style="vertical-align:top;width:600px;">
+                        <![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td style="width:128px;">
-                                                                        <img height="auto"
-                                                                            alt="Image"
-                                                                            src="<?php echo $product->get_image(); ?>"
-                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                            width="128">
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                    </td>
-                                                </tr>
+                                            <tr>
+                                                <td style="width:128px;">
+                                                    <img height="auto"
+                                                         alt="Image"
+                                                         src="<?php echo $product->get_image(); ?>"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="128">
+                                                </td>
+                                            </tr>
                                             </tbody>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]></td><![endif]-->
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td><![endif]-->
 
-                                    <!--[if mso | IE]>
-                                <td class="" style="vertical-align:top;width:150px;">
-                                <![endif]-->
-                                    <div class="mj-column-per-25 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
-                                            <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
-                                                            <?php echo $line_item->get_name() ?>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td align="center" vertical-align="middle"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:separate;line-height:100%;">
-                                                            <tr>
-                                                                <td align="center"
-                                                                    role="presentation"
-                                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
-                                                                    valign="middle">
-                                                                    <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo $brandSettings->getButtonBgColor() ?>;color:<?php echo $brandSettings->getButtonTextColor() ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo $brandSettings->getButtonBorderColor() ?>"
-                                                                        target="_blank">
-                                                                        {button_text}
-                                                                    </a>
-                                                                </td>
-                                                            </tr>
-                                                        </table>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
+                        <!--[if mso | IE]>
+                        <td class="" style="vertical-align:top;width:150px;">
+                        <![endif]-->
+                        <div class="mj-column-per-25 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
+                                            <?php echo $line_item->get_name() ?>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" vertical-align="middle"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:separate;line-height:100%;">
+                                            <tr>
+                                                <td align="center"
+                                                    role="presentation"
+                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
+                                                    valign="middle">
+                                                    <a href="<?php echo $reviewLink ?>"
+                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                       target="_blank">
+                                                        {button_text}
+                                                    </a>
+                                                </td>
+                                            </tr>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]>
-                            </td>
-                                <![endif]-->
-                                    <!--[if mso | IE]>
-                            </tr>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]>
+                        </td>
+                        <![endif]-->
+                        <!--[if mso | IE]>
+                        </tr>
                         </table>
-                                <![endif]-->
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <!--[if mso | IE]>
-            </td>
-            </tr>
+                        <![endif]-->
+                    </td>
+                </tr>
+                </tbody>
             </table>
-    <![endif]-->
-            <?php } ?>
+        </div>
+        <!--[if mso | IE]>
+        </td>
+        </tr>
+        </table>
+        <![endif]-->
+    <?php } ?>
 
-            <!--[if mso | IE]>
+    <!--[if mso | IE]>
 <?php if ($generalSettings->isFooterEnabled()): ?>
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="width:600px;"
            width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
-                                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                    <tr>
-                                        <td class="" style="vertical-align:top;width:600px;">
-                                <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>;">
-                                                        {footer_text}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>">
-                                                        <a href="{unsubscribe_link}">Unsubscribe</a>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
-                                </tr>
-                                </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
-            </td>
-        </tr>
-    </table>
-<![endif]-->
-        <?php endif ?>
-
-        <!--[if mso | IE]>
-                <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                       style="width:600px;" width="600">
-                    <tr>
-                        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-                <![endif]-->
-        <div style="margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0"
-                role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                            <!--[if mso | IE]>
-                                            <table role="presentation" border="0" cellpadding="0"
-                                                   cellspacing="0">
-                                                <tr></tr>
-                                            </table><![endif]-->
-                        </td>
+                            <td class="" style="vertical-align:top;width:600px;">
+                    <![endif]-->
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
+                                        {footer_text}
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;">
+                                        <a href="{unsubscribe_link}">Unsubscribe</a>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
-                       </td>
-                   </tr>
-                </table>
-                <![endif]-->
+                    </table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
     </div>
+<!--[if mso | IE]>
+</td>
+</tr>
+</table>
+<![endif]-->
+<?php endif ?>
+
+    <!--[if mso | IE]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
+           style="width:600px;" width="600">
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+    <![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0"
+               role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0"
+                           cellspacing="0">
+                        <tr></tr>
+                    </table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/review-reminder.php
+++ b/Core/Emails/views/review-reminder.php
@@ -10,7 +10,9 @@
     <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php  $fontStyles = apply_filters('get_desired_font_style', []); ?>
         #outlook a {
             padding: 0;
         }
@@ -103,9 +105,8 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:<?php
-                                                    echo $brandSettings->getEmailBgColor() ?>;color: <?php echo $brandSettings->getTextColor() ?>">
-    <div>
+<body style="word-spacing:normal;">
+    <div class= "<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>; border;; border-radius:15px 15px 15px 15px; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -206,7 +207,7 @@
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
                                 <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%; background-color: <?php echo $brandSettings->getContentBgColor() ?>;">
+                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
@@ -252,7 +253,7 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
             <![endif]-->
-            <div style="background-color:<?php echo $brandSettings->getContentBgColor() ?>;margin:0px auto;max-width:600px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                     style="width:100%;">
                     <tbody>
@@ -303,10 +304,10 @@
                 ?>
                 <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
-    <tr bgcolor="<?php echo $brandSettings->getContentBgColor() ?>">
+    <tr bgcolor="">
     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
    <![endif]-->
-                <div style="margin:0px auto;max-width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>">
+                <div style="margin:0px auto;max-width:600px;">
                     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                         style="width:100%;">
                         <tbody>
@@ -377,7 +378,7 @@
                                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                                     valign="middle">
                                                                     <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo $brandSettings->getButtonBgColor() ?>;color:<?php echo $brandSettings->getButtonTextColor() ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo $brandSettings->getButtonBorderColor() ?>"
+                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['button_text_color']); ?>; border:;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']); ?>;"
                                                                         target="_blank">{button_text}
                                                                     </a>
                                                                 </td>
@@ -433,7 +434,7 @@
                                             <tr>
                                                 <td align="center"
                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>;">
+                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
                                                         {footer_text}
                                                     </div>
                                                 </td>
@@ -441,7 +442,7 @@
                                             <tr>
                                                 <td align="center"
                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>">
+                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;">
                                                         <a href="{unsubscribe_link}">Unsubscribe</a>
                                                     </div>
                                                 </td>

--- a/Core/Emails/views/review-reminder.php
+++ b/Core/Emails/views/review-reminder.php
@@ -106,7 +106,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class= "<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>; border;; border-radius:15px 15px 15px 15px; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div  class= "<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>; border;; border-radius:15px 15px 15px 15px; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>

--- a/Core/Emails/views/review-reply.php
+++ b/Core/Emails/views/review-reply.php
@@ -86,10 +86,10 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; text-color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
+    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-           bgcolor="#F5CEE4">
+           >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:20px auto;max-width:600px;">
@@ -129,7 +129,7 @@
         <?php if ($brandSettings->isLogoEnabled()): ?>
             <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-            bgcolor="#EDE4E7">
+            >
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
             <div style="margin:0px auto;max-width:600px;">
@@ -181,7 +181,7 @@
 
         <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-            bgcolor="#FFFFFF">
+            >
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
         <div style="margin:0px auto;max-width:600px;">
@@ -198,7 +198,7 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="" width="NaN" bgcolor="#fadfdb">
+                                       style="" >
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
@@ -249,7 +249,7 @@
                             <!--[if mso | IE]>
                         <td class="" style="">
                             <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#fadfdb">
+                                >
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                             <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
@@ -296,13 +296,13 @@
                             <!--[if mso | IE]>
                         <td class="" style="">
                             <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:NaNpx;"
-                                width="NaN" bgcolor="#ffffff">
+                                >
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;">
+                            <div style="margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#ffffff;background-color:#ffffff;width:100%;">
+                                    style="width:100%;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -320,8 +320,8 @@
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                                                         <p
-                                                                            style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
-                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #C3C3C3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
+                                                                            style="border-top:solid 2px ;font-size:1px;margin:0px auto;width:100%;"></p><!--[if mso | IE]>
+                                                    <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px 3;font-size:1px;margin:0px auto;width:NaNpx;" role="presentation" width="NaNpx">
                                                         <tr>
                                                             <td style="height:0;line-height:0;"> &nbsp;
                                                             </td>
@@ -332,12 +332,12 @@
                                                                 <tr>
                                                                     <td align="center"
                                                                         style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;color:#C2C2C2;">
+                                                                        <div style="font-family:Helvetica, sans-serif;font-size:14px;line-height:1;text-align:center;">
                                                                             <p>{footer_text}</p>
                                                                             <a
                                                                                 data-cke-saved-href="http://localhost:7000"
                                                                                 href="#"
-                                                                                style="color:#c2c2c2;"><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
+                                                                                style=""><?php echo esc_attr('Unsubscribe', 'f-review') ?></a><br>
                                                                         </div>
                                                                     </td>
                                                                 </tr>

--- a/Core/Emails/views/review-reply.php
+++ b/Core/Emails/views/review-reply.php
@@ -86,7 +86,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; text-color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
+    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; text-color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            bgcolor="#F5CEE4">

--- a/Core/Emails/views/review-reply.php
+++ b/Core/Emails/views/review-reply.php
@@ -7,7 +7,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -83,16 +85,16 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:#EDE4E7;">
-    <div style="background-color:#EDE4E7;">
+<body style="word-spacing:normal;">
+    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border-radius:15px 15px 15px 15px; text-color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            bgcolor="#F5CEE4">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#F5CEE4;background-color:#F5CEE4;margin:20px auto;max-width:600px;">
+        <div style="margin:20px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#F5CEE4;background-color:#F5CEE4;width:100%;">
+                style="width:100%;">
                 <tbody>
                     <tr>
                         <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -130,9 +132,9 @@
             bgcolor="#EDE4E7">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-            <div style="background:#EDE4E7;background-color:#EDE4E7;margin:0px auto;max-width:600px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="background:#EDE4E7;background-color:#EDE4E7;width:100%;">
+                    style="width:100%;">
                     <tbody>
                         <tr>
                             <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -182,12 +184,12 @@
             bgcolor="#FFFFFF">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                style="background:#ffffff;background-color:#ffffff;width:100%;">
+                style="width:100%;">
                 <tbody>
                     <tr>
-                        <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:NaNpx;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                        <td style="direction:ltr;font-size:0px;text-align:center;">
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
@@ -196,20 +198,20 @@
                                 <!--[if mso | IE]>
                             <td class="" style="">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
-                                       style="width:NaNpx;" width="NaN" bgcolor="#fadfdb">
+                                       style="" width="NaN" bgcolor="#fadfdb">
                                     <tr>
                                         <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
                     <![endif]-->
-                                <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
+                                <div style="margin:0px auto;border-radius:15px 15px 0 0;max-width:NaNpx;">
                                     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:15px 15px 0 0;">
+                                        style="width:100%;border-radius:15px 15px 0 0;">
                                         <tbody>
                                             <tr>
-                                                <td style="direction:ltr;font-size:0px;padding:NaNpx;padding-bottom:0px;padding-left:NaNpx;padding-right:NaNpx;padding-top:NaNpx;text-align:center;">
+                                                <td style="direction:ltr;font-size:0px;text-align:center;">
                                                     <!--[if mso | IE]>
                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                         <tr>
-                                            <td class="" style="vertical-align:top;width:NaNpx;"><![endif]-->
+                                            <td class="" style="vertical-align:top;"><![endif]-->
                                                     <div class="mj-column-per-100 mj-outlook-group-fix"
                                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
@@ -250,9 +252,9 @@
                                 width="NaN" bgcolor="#fadfdb">
                                 <tr>
                                     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                            <div style="background:#fadfdb;background-color:#fadfdb;margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
+                            <div style="margin:0px auto;border-radius:0 0 15px 15px;max-width:NaNpx;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                    style="background:#fadfdb;background-color:#fadfdb;width:100%;border-radius:0 0 15px 15px;">
+                                    style="width:100%;border-radius:0 0 15px 15px;">
                                     <tbody>
                                         <tr>
                                             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0px;padding-top:0px;text-align:center;">
@@ -268,7 +270,7 @@
                                                             <tr>
                                                                 <td align="left"
                                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;">
+                                                                    <div style="font-family:Helvetica, sans-serif;font-size:16px;line-height:1.5;text-align:left;">
                                                                         {body}
                                                                     </div>
                                                                 </td>
@@ -298,7 +300,7 @@
                                 <tr>
 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:NaNpx;">
+                            <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;">
                                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                                     style="background:#ffffff;background-color:#ffffff;width:100%;">
                                     <tbody>

--- a/Core/Emails/views/review-request.php
+++ b/Core/Emails/views/review-request.php
@@ -10,7 +10,9 @@
     <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php echo apply_filters('get_google_font_link_for_email_template', ''); ?>
     <style type="text/css">
+        <?php $fontStyles = apply_filters('get_desired_font_style', []);?>
         #outlook a {
             padding: 0;
         }
@@ -103,9 +105,8 @@
     </style>
 </head>
 
-<body style="word-spacing:normal;background-color:<?php
-                                                    echo $brandSettings->getEmailBgColor() ?>;color: <?php echo $brandSettings->getTextColor() ?>">
-    <div>
+<body style="word-spacing:normal;">
+    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -252,7 +253,7 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
             <![endif]-->
-            <div style="background-color:<?php echo $brandSettings->getContentBgColor() ?>;margin:0px auto;max-width:600px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                     style="width:100%;">
                     <tbody>
@@ -302,10 +303,10 @@
                 ?>
                 <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
-    <tr bgcolor="<?php echo $brandSettings->getContentBgColor() ?>">
+    <tr bgcolor="<?php echo esc_attr($data['styles']['email_bg_color']); ?>">
     <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
    <![endif]-->
-                <div style="margin:0px auto;max-width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>">
+                <div style="margin:0px auto;max-width:600px;">
                     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                         style="width:100%;">
                         <tbody>
@@ -376,7 +377,7 @@
                                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                                     valign="middle">
                                                                     <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo $brandSettings->getButtonBgColor() ?>;color:<?php echo $brandSettings->getButtonTextColor() ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo $brandSettings->getButtonBorderColor() ?>"
+                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']) ?>"
                                                                         target="_blank">
                                                                         {button_text}
                                                                     </a>
@@ -433,7 +434,7 @@
                                             <tr>
                                                 <td align="center"
                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>;">
+                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;">
                                                         {footer_text}
                                                     </div>
                                                 </td>
@@ -441,7 +442,7 @@
                                             <tr>
                                                 <td align="center"
                                                     style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:<?php echo $brandSettings->getTextColor() ?>">
+                                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;">
                                                         <a href="{unsubscribe_link}">Unsubscribe</a>
                                                     </div>
                                                 </td>

--- a/Core/Emails/views/review-request.php
+++ b/Core/Emails/views/review-request.php
@@ -106,7 +106,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div  class="<?php echo esc_attr($fontStyles['class']); ?>" style="background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; border:; border-radius: 15px 15px 15px 15px; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>

--- a/flycart-reviews.php
+++ b/flycart-reviews.php
@@ -199,3 +199,17 @@ add_action('admin_head', function () {
 <?php
     }
 }, 11);
+
+add_action('get_google_font_link_for_email_template' , function(){
+    return '<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">';
+});
+
+add_action('get_desired_font_style', function () {
+    $fontStyles = [
+        ['class' => 'dm-serif-text-regular', 'content' => 'font-weight: 400; font-style: normal;'],
+        ['class' => 'dm-serif-text-regular-italic', 'content' => 'font-weight: 400; font-style: italic;'],
+    ];
+    return $fontStyles;
+});

--- a/flycart-reviews.php
+++ b/flycart-reviews.php
@@ -206,10 +206,9 @@ add_action('get_google_font_link_for_email_template' , function(){
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">';
 });
 
-add_action('get_desired_font_style', function () {
-    $fontStyles = [
-        ['class' => 'dm-serif-text-regular', 'content' => 'font-weight: 400; font-style: normal;'],
-        ['class' => 'dm-serif-text-regular-italic', 'content' => 'font-weight: 400; font-style: italic;'],
+add_filter('get_desired_font_style', function () {
+    return [
+        'class' => 'dm-serif-text-regular  dm-serif-text-regular-italic',
+        'content' => 'font-weight: 400; font-style: normal; font-family: "DM Serif Text", serif; font-weight: 400; font-style: italic;'
     ];
-    return $fontStyles;
 });

--- a/flycart-reviews.php
+++ b/flycart-reviews.php
@@ -209,6 +209,6 @@ add_action('get_google_font_link_for_email_template' , function(){
 add_filter('get_desired_font_style', function () {
     return [
         'class' => 'dm-serif-text-regular  dm-serif-text-regular-italic',
-        'content' => 'font-weight: 400; font-style: normal; font-family: "DM Serif Text", serif; font-weight: 400; font-style: italic;'
+        'content' => 'font-weight: 400; font-style: normal;  font-family: "DM Serif Text", serif; font-weight: 400; font-style: italic;'
     ];
 });


### PR DESCRIPTION
Adds default styles and font to the discount reminder email template to improve its visual consistency. This includes:

- Defining default styles for email background, text, button background, button text, and button border colors.
- Using the 'DM Serif Text' font for the email content.
- Updating the email template to utilize these styles and font.
- Adding actions to include Google Fonts and font styles in the email template.