### PR TITLE
Fix(emails): Improve email layout and branding

### DIFF
--- a/Core/Emails/views/discount-notify.php
+++ b/Core/Emails/views/discount-notify.php
@@ -86,17 +86,17 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="max-width:600px;background-color:<?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+        <div style="margin:0px auto;max-width:600px;background-color:<?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                 <tbody>
                     <tr>
-                        <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
+                        <td style="direction:ltr;font-size:0px;text-align:center;">
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
@@ -119,7 +119,7 @@
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;padding:10px 10px;">
+            <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
                         <tr>
@@ -134,16 +134,16 @@
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                                         alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -170,7 +170,7 @@
            >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="max-width:600px; background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']);?>;">
+        <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']);?>;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                 style="width:100%;">
                 <tbody>
@@ -211,10 +211,12 @@
                                                                             style="border-collapse:collapse;border-spacing:0px;">
                                                                             <tbody>
                                                                                 <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="{banner_src}"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
+                                                                                    <td style="width:100%;">
+                                                                                        <img height="auto"
+                                                                                             src="{logo_src}"
+                                                                                             style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                                             alt="">
+                                                                                    </td>
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>

--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -95,7 +95,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>"><!--[if mso | IE]>
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>"><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            >
         <tr>
@@ -112,18 +112,18 @@
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
                                 <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                    style="font-size:0px;text-align:center;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td style="vertical-align:top;padding:10px 100px;">
+                                                <td style="vertical-align:top;padding:20px;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
                                                                          src="{logo_src}"
-                                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
                                                                          alt="">
                                                                 </td>
                                                             </tr>
@@ -165,15 +165,17 @@
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                <td align="center" style="font-size:0px;padding:10px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:215px;"><img height="auto"
-                                                                        src="https://static.flycart.net/email_customizer_advance/image/editor/logo.png"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="215"></td>
+                                                                <td style="width:100%;">
+                                                                    <img height="auto"
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                         alt="">
+                                                                </td>
                                                             </tr>
                                                         </tbody>
                                                     </table>

--- a/Core/Emails/views/photo-request.php
+++ b/Core/Emails/views/photo-request.php
@@ -85,13 +85,13 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
         <!--[if mso | IE]>
    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
        <tr>
            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
    <![endif]-->
-        <div style="margin:20px auto;max-width:600px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                 <tbody>
                     <tr>
@@ -133,16 +133,16 @@
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                                         alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -210,10 +210,12 @@
                                                                             style="border-collapse:collapse;border-spacing:0px;">
                                                                             <tbody>
                                                                                 <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="{banner_src}"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
+                                                                                    <td style="width:100%;">
+                                                                                        <img height="auto"
+                                                                                             src="{logo_src}"
+                                                                                             style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                                             alt="">
+                                                                                    </td>
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>
@@ -280,7 +282,7 @@
                                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
                                                                                 <p
-                                                                                    style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                                    style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
                                                                                     {button_text}
                                                                                 </p>
                                                                             </td>

--- a/Core/Emails/views/plain/discount-notify.php
+++ b/Core/Emails/views/plain/discount-notify.php
@@ -86,17 +86,17 @@
 </head>
 
 <body style="word-spacing:normal;">
-<div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;  color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
     <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-    <div style="max-width:600px;background-color:<?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+    <div style="margin:0px auto;max-width:600px;background-color:<?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
             <tbody>
             <tr>
-                <td style="direction:ltr;font-size:0px;padding:'20px 0px';text-align:center;">
+                <td style="direction:ltr;font-size:0px;text-align:center;">
                     <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
@@ -119,7 +119,7 @@
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-        <div style="margin:0px auto;max-width:600px;padding:10px 10px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                 <tbody>
                 <tr>
@@ -134,16 +134,16 @@
                                    style="vertical-align:top;" width="100%">
                                 <tbody>
                                 <tr>
-                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                    <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
                                             <tr>
-                                                <td style="width:50px;">
+                                                <td style="width:100%;">
                                                     <img height="auto"
                                                          src="{logo_src}"
-                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                         width="50" alt="">
+                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                         alt="">
                                                 </td>
                                             </tr>
                                             </tbody>
@@ -170,7 +170,7 @@
     >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="max-width:600px; background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']);?>;">
+    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']);?>;">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                style="width:100%;">
             <tbody>
@@ -211,10 +211,12 @@
                                                                style="border-collapse:collapse;border-spacing:0px;">
                                                             <tbody>
                                                             <tr>
-                                                                <td style="width:100%;"><img height="auto"
-                                                                                             src="{banner_src}"
-                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                             width="100%"></td>
+                                                                <td style="width:100%;">
+                                                                    <img height="auto"
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                         alt="">
+                                                                </td>
                                                             </tr>
                                                             </tbody>
                                                         </table>

--- a/Core/Emails/views/plain/discount-reminder.php
+++ b/Core/Emails/views/plain/discount-reminder.php
@@ -95,7 +95,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-<div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>"><!--[if mso | IE]>
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>"><!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
     >
         <tr>
@@ -112,18 +112,18 @@
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
                     <div class="mj-column-per-100 mj-outlook-group-fix"
-                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                         style="font-size:0px;text-align:center;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                             <tbody>
                             <tr>
-                                <td style="vertical-align:top;padding:10px 100px;">
+                                <td style="vertical-align:top;padding:20px;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                                         <tbody>
                                         <tr>
-                                            <td style="width:50px;">
+                                            <td style="width:100%;">
                                                 <img height="auto"
                                                      src="{logo_src}"
-                                                     style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                     style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
                                                      alt="">
                                             </td>
                                         </tr>
@@ -165,15 +165,17 @@
                                    style="vertical-align:top;" width="100%">
                                 <tbody>
                                 <tr>
-                                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <td align="center" style="font-size:0px;padding:10px;word-break:break-word;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
                                             <tr>
-                                                <td style="width:215px;"><img height="auto"
-                                                                              src="https://static.flycart.net/email_customizer_advance/image/editor/logo.png"
-                                                                              style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                              width="215"></td>
+                                                <td style="width:100%;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                         alt="">
+                                                </td>
                                             </tr>
                                             </tbody>
                                         </table>

--- a/Core/Emails/views/plain/photo-request.php
+++ b/Core/Emails/views/plain/photo-request.php
@@ -85,13 +85,13 @@
 </head>
 
 <body style="word-spacing:normal;">
-<div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom: 10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
     <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-    <div style="margin:20px auto;max-width:600px;">
+    <div style="margin:0px auto;max-width:600px;">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
             <tbody>
             <tr>
@@ -133,16 +133,16 @@
                                    style="vertical-align:top;" width="100%">
                                 <tbody>
                                 <tr>
-                                    <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                    <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
                                             <tr>
-                                                <td style="width:50px;">
+                                                <td style="width:100%;">
                                                     <img height="auto"
                                                          src="{logo_src}"
-                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                         width="50" alt="">
+                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                         alt="">
                                                 </td>
                                             </tr>
                                             </tbody>
@@ -210,10 +210,12 @@
                                                                style="border-collapse:collapse;border-spacing:0px;">
                                                             <tbody>
                                                             <tr>
-                                                                <td style="width:100%;"><img height="auto"
-                                                                                             src="{banner_src}"
-                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                             width="100%"></td>
+                                                                <td style="width:100%;">
+                                                                    <img height="auto"
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                         alt="">
+                                                                </td>
                                                             </tr>
                                                             </tbody>
                                                         </table>
@@ -280,7 +282,7 @@
                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                 valign="middle">
                                                                 <p
-                                                                        style="display:inline-block;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
                                                                     {button_text}
                                                                 </p>
                                                             </td>

--- a/Core/Emails/views/plain/review-reminder.php
+++ b/Core/Emails/views/plain/review-reminder.php
@@ -1,6 +1,6 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
-    xmlns:o="urn:schemas-microsoft-com:office:office">
+      xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
     <title>
@@ -11,14 +11,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php echo apply_filters('farp_prefix_get_google_font_link_for_email_template', ''); ?>
-
-    <?php
-    $fontStyles = apply_filters('farp_prefix_get_desired_font_style', []);
-    error_log(print_r($fontStyles, true));
-    ?>
-
     <style type="text/css">
-        #outlook a {
+        <?php $fontStyles = apply_filters('farp_prefix_get_desired_font_style', []); ?>#outlook a {
             padding: 0;
         }
 
@@ -111,141 +105,141 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>;  <?php echo esc_attr($fontStyles['content']); ?>">
-        <!--[if mso | IE]>
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>;  <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-        <div style="margin:0px auto;max-width:600px;">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                <tbody>
-                    <tr>
-                        <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
-                            <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr></tr>
                     </table>
                     <![endif]-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
-        <?php if ($brandSettings->isLogoEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isLogoEnabled()) { ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
             <tr>
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-            <div style="margin:0px auto;max-width:600px;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;text-align:center;">
-                                <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
+                                                <td style="width:100%;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                         alt="">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table><![endif]-->
-        <?php } ?>
+    <?php } ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;background-color:<?php echo $brandSettings->getContentBgColor() ?>" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
-            <!--[if mso | IE]>
+    <?php if ($brandSettings->isEmailBannerEnabled()) { ?>
+    <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class=""
            style="width:600px; background-color: <?php echo $brandSettings->getContentBgColor() ?>;" width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
     <![endif]-->
-            <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;"><![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px;word-break:break-word;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
+                                           style="border-collapse:collapse;border-spacing:0px;">
                                         <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
-                                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                                        style="border-collapse:collapse;border-spacing:0px;">
-                                                        <tbody>
-                                                            <tr>
-                                                                <td style="width:50px;">
-                                                                    <img height="auto"
-                                                                        src="{banner_src}"
-                                                                        alt=""
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </td>
-                                            </tr>
+                                        <tr>
+                                            <td style="width:100%;">
+                                                <img height="auto"
+                                                     src="{logo_src}"
+                                                     style="border:0;display:block;outline:none;text-decoration:none;width:100%;font-size:13px;"
+                                                     alt="">
+                                            </td>
+                                        </tr>
                                         </tbody>
                                     </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+<!--[if mso | IE]>
     </td>
     </tr>
     </table>
@@ -258,221 +252,222 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
             <![endif]-->
-            <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <!--[if mso | IE]>
         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
             <tr>
         <!--[if mso | IE]>
         <td class="" style="vertical-align:top;width:600px;">
         <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="left"
-                                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
-                                                    <div style="font-size:14px;line-height:28px;text-align:left;">
-                                                        {body}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="left"
+                                    style="font-size:0px;padding:0px 25px 0px 25px;word-break:break-word;">
+                                    <div style="font-size:14px;line-height:28px;text-align:left;">
+                                        {body}
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!--[if mso | IE]>
     </td>
     </tr>
     </table>
     <![endif]-->
 
 
-            <?php foreach ($order->get_items() as $line_item) { ?>
-                <?php
-                $product_id = $line_item['product_id'];
-                $product = wc_get_product($product_id);
-                $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
-                ?>
-                <!--[if mso | IE]>
+    <?php foreach ($order->get_items() as $line_item) { ?>
+        <?php
+        $product_id = $line_item['product_id'];
+        $product = wc_get_product($product_id);
+        $reviewLink = \Flycart\Review\App\Helpers\PluginHelper::getReviewLink($order, $product_id);
+        ?>
+        <!--[if mso | IE]>
         <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;"width="600">
             <tr bgcolor="">
                 <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
         <![endif]-->
-                <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
-                    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="width:100%;">
-                        <tbody>
-                            <tr>
-                                <td style="direction:ltr;font-size:0px;text-align:center;">
-                                    <!--[if mso | IE]>
+        <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                   style="width:100%;">
+                <tbody>
+                <tr>
+                    <td style="direction:ltr;font-size:0px;text-align:center;">
+                        <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                         <![endif]-->
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:600px;">
                         <![endif]-->
-                                    <div class="mj-column-per-100 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:collapse;border-spacing:0px;">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td style="width:108px;">
-                                                                        <img height="auto"
-                                                                            alt="Image"
-                                                                            src="<?php echo $product->get_image(); ?>"
-                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                            width="128">
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                    </td>
-                                                </tr>
+                                            <tr>
+                                                <td style="width:108px;">
+                                                    <img height="auto"
+                                                         alt="Image"
+                                                         src="<?php echo $product->get_image(); ?>"
+                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                         width="128">
+                                                </td>
+                                            </tr>
                                             </tbody>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]></td><![endif]-->
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]></td><![endif]-->
 
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                                    <div class="mj-column-per-25 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                            style="vertical-align:top;" width="100%">
-                                            <tbody>
-                                                <tr>
-                                                    <td align="center"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <div style="font-size:13px;line-height:1;text-align:center;">
-                                                            <?php echo $line_item->get_name() ?>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td align="center" vertical-align="middle"
-                                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                                        <table border="0" cellpadding="0" cellspacing="0"
-                                                            role="presentation"
-                                                            style="border-collapse:separate;line-height:100%;">
-                                                            <tr>
-                                                                <td align="center"
-                                                                    role="presentation"
-                                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
-                                                                    valign="middle">
-                                                                    <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['button_text_color']); ?>; border:2px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;min-width:max-content;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']); ?>;"
-                                                                        target="_blank">{button_text}
-                                                                    </a>
-                                                                </td>
-                                                            </tr>
-                                                        </table>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
+                        <div class="mj-column-per-25 mj-outlook-group-fix"
+                             style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                   style="vertical-align:top;" width="100%">
+                                <tbody>
+                                <tr>
+                                    <td align="center"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <div style="font-size:13px;line-height:1;text-align:center;">
+                                            <?php echo $line_item->get_name() ?>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" vertical-align="middle"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0"
+                                               role="presentation"
+                                               style="border-collapse:separate;line-height:100%;">
+                                            <tr>
+                                                <td align="center"
+                                                    role="presentation"
+                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
+                                                    valign="middle">
+                                                    <a href="<?php echo $reviewLink ?>"
+                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                       target="_blank">
+                                                        {button_text}
+                                                    </a>
+                                                </td>
+                                            </tr>
                                         </table>
-                                    </div>
-                                    <!--[if mso | IE]>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!--[if mso | IE]>
                         </td>
                         <![endif]-->
-                                    <!--[if mso | IE]>
+                        <!--[if mso | IE]>
                         </tr>
                         </table>
                         <![endif]-->
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <!--[if mso | IE]>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!--[if mso | IE]>
         </td>
         </tr>
         </table>
         <![endif]-->
-            <?php } ?>
+    <?php } ?>
 
-            <!--[if mso | IE]>
+    <!--[if mso | IE]>
 <?php if ($generalSettings->isFooterEnabled()): ?>
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="width:600px;"
            width="600">
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-            <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
-                    style="width:100%;">
-                    <tbody>
-                        <tr>
-                            <td style="direction:ltr;font-size:0px;padding:5px 0;text-align:center;">
-                                <!--[if mso | IE]>
+    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+               style="width:100%;">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0px;padding:5px 0;text-align:center;">
+                    <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td class="" style="vertical-align:top;width:600px;">
                     <![endif]-->
-                                <div class="mj-column-per-100 mj-outlook-group-fix"
-                                    style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                    <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                                        style="vertical-align:top;" width="100%">
-                                        <tbody>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                                    <div style="font-size:13px;line-height:1;text-align:center;">
-                                                        {footer_text}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td align="center"
-                                                    style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                                    <div style="font-size:10px;line-height:1;text-align:center;">
-                                                        <a href="{unsubscribe_link}">Unsubscribe</a>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!--[if mso | IE]></td>
+                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="vertical-align:top;" width="100%">
+                            <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                    <div style="font-size:13px;line-height:1;text-align:center;">
+                                        {footer_text}
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center"
+                                    style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                    <div style="font-size:10px;line-height:1;text-align:center;">
+                                        <a href="{unsubscribe_link}">Unsubscribe</a>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!--[if mso | IE]></td>
                     </tr>
                     </table><![endif]-->
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!--[if mso | IE]>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+<!--[if mso | IE]>
 </td>
 </tr>
 </table>
 <![endif]-->
-        <?php endif ?>
+<?php endif ?>
 
-        <!--[if mso | IE]>
+    <!--[if mso | IE]>
     <![endif]-->
-    </div>
+</div>
 </body>
 
 </html>

--- a/Core/Emails/views/plain/review-reply.php
+++ b/Core/Emails/views/plain/review-reply.php
@@ -85,13 +85,13 @@
 </head>
 
 <body style="word-spacing:normal;">
-<div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
     <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
     >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:20px auto;max-width:600px;">
+    <div style="margin:0px auto;max-width:600px;">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                style="width:100%;">
             <tbody>
@@ -100,7 +100,7 @@
                     <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                            <td style="vertical-align:top;width:600px;"><![endif]-->
                     <div class="mj-column-per-100 mj-outlook-group-fix"
                          style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
@@ -147,15 +147,17 @@
                                    style="vertical-align:top;" width="100%">
                                 <tbody>
                                 <tr>
-                                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
                                             <tr>
-                                                <td style="width:45px;"><img height="auto"
-                                                                             src="{logo_src}"
-                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                             width="45"></td>
+                                                <td style="width:100%;">
+                                                    <img height="auto"
+                                                         src="{logo_src}"
+                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                         alt="">
+                                                </td>
                                             </tr>
                                             </tbody>
                                         </table>
@@ -224,10 +226,12 @@
                                                                style="border-collapse:collapse;border-spacing:0px;">
                                                             <tbody>
                                                             <tr>
-                                                                <td style="width:100%;"><img height="auto"
-                                                                                             src="<?php echo $brandSettings->getEmailBanner() ?>"
-                                                                                             style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                             width="100%"></td>
+                                                                <td style="width:100%;">
+                                                                    <img height="auto"
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                         alt="">
+                                                                </td>
                                                             </tr>
                                                             </tbody>
                                                         </table>

--- a/Core/Emails/views/plain/review-request.php
+++ b/Core/Emails/views/plain/review-request.php
@@ -105,7 +105,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-<div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+<div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
     <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -142,7 +142,7 @@
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                 <tbody>
                 <tr>
-                    <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                    <td style="direction:ltr;font-size:0px;padding:20px;text-align:center;">
                         <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
@@ -158,11 +158,11 @@
                                                style="border-collapse:collapse;border-spacing:0px;">
                                             <tbody>
                                             <tr>
-                                                <td style="width:50px;">
+                                                <td style="width:100%;">
                                                     <img height="auto"
                                                          src="{logo_src}"
-                                                         style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                         width="50" alt="">
+                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                         alt="">
                                                 </td>
                                             </tr>
                                             </tbody>
@@ -212,16 +212,16 @@
                             <tbody>
                             <tr>
                                 <td align="center"
-                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                    style="font-size:0px;padding:10px;word-break:break-word;">
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                            style="border-collapse:collapse;border-spacing:0px;">
                                         <tbody>
                                         <tr>
                                             <td style="width:100%;">
                                                 <img height="auto"
-                                                     src="{banner_src}"
-                                                     alt=""
-                                                     style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
+                                                     src="{logo_src}"
+                                                     style="border:0;display:block;outline:none;text-decoration:none;width:100%;font-size:13px;"
+                                                     alt="">
                                             </td>
                                         </tr>
                                         </tbody>
@@ -257,7 +257,7 @@
                style="width:100%;">
             <tbody>
             <tr>
-                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <td style="direction:ltr;font-size:0px;padding:20px;text-align:center;">
                     <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
@@ -413,7 +413,7 @@
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
 <![endif]-->
-    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']);?>;">
+    <div style="margin:0px auto;max-width:600px;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                style="width:100%;">
             <tbody>

--- a/Core/Emails/views/review-reminder.php
+++ b/Core/Emails/views/review-reminder.php
@@ -105,7 +105,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>;  <?php echo esc_attr($fontStyles['content']); ?>">
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['email_text_color']); ?>;  <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -153,16 +153,16 @@
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                                         alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -212,16 +212,16 @@
                                         <tbody>
                                             <tr>
                                                 <td align="center"
-                                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                                    style="font-size:0px;padding:10px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{banner_src}"
-                                                                        alt=""
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;text-decoration:none;width:100%;font-size:13px;"
+                                                                          alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -377,8 +377,8 @@
                                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                                     valign="middle">
                                                                     <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color: <?php echo esc_attr($data['styles']['button_text_color']); ?>; border:2px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;min-width:max-content;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border-color:<?php echo esc_attr($data['styles']['button_border_color']); ?>;"
-                                                                        target="_blank">
+                                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                                       target="_blank">
                                                                         {button_text}
                                                                     </a>
                                                                 </td>

--- a/Core/Emails/views/review-reply.php
+++ b/Core/Emails/views/review-reply.php
@@ -85,13 +85,13 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo esc_attr($fontStyles['content']); ?>">
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px; background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?> <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
            >
         <tr>
             <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-        <div style="margin:20px auto;max-width:600px;">
+        <div style="margin:0px auto;max-width:600px;">
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
                 style="width:100%;">
                 <tbody>
@@ -100,7 +100,7 @@
                             <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>
-                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+                            <td style="vertical-align:top;width:600px;"><![endif]-->
                             <div class="mj-column-per-100 mj-outlook-group-fix"
                                 style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
@@ -147,15 +147,17 @@
                                         style="vertical-align:top;" width="100%">
                                         <tbody>
                                             <tr>
-                                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:45px;"><img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="45"></td>
+                                                                <td style="width:100%;">
+                                                                    <img height="auto"
+                                                                         src="{logo_src}"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                                         alt="">
+                                                                </td>
                                                             </tr>
                                                         </tbody>
                                                     </table>
@@ -224,10 +226,12 @@
                                                                             style="border-collapse:collapse;border-spacing:0px;">
                                                                             <tbody>
                                                                                 <tr>
-                                                                                    <td style="width:100%;"><img height="auto"
-                                                                                            src="<?php echo $brandSettings->getEmailBanner() ?>"
-                                                                                            style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                                            width="100%"></td>
+                                                                                    <td style="width:100%;">
+                                                                                        <img height="auto"
+                                                                                             src="{logo_src}"
+                                                                                             style="border:0;display:block;outline:none;width:100%;text-decoration:none;font-size:13px;"
+                                                                                             alt="">
+                                                                                    </td>
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>

--- a/Core/Emails/views/review-request.php
+++ b/Core/Emails/views/review-request.php
@@ -105,7 +105,7 @@
 </head>
 
 <body style="word-spacing:normal;">
-    <div class="<?php echo esc_attr($fontStyles['class']); ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo esc_attr($fontStyles['content']); ?>">
+    <div class="<?php echo isset($fontStyles['class']) ? esc_attr($fontStyles['class']) : ''; ?>" style="padding-bottom:10px;background-color:<?php echo esc_attr($data['styles']['email_bg_color']); ?>; color:<?php echo esc_attr($data['styles']['email_text_color']); ?>; <?php echo isset($fontStyles['content']) ? esc_attr($fontStyles['content']) : ''; ?>">
         <!--[if mso | IE]>
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600">
         <tr>
@@ -142,7 +142,7 @@
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
                         <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                            <td style="direction:ltr;font-size:0px;padding:20px;text-align:center;">
                                 <!--[if mso | IE]>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
@@ -158,11 +158,11 @@
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="width:50px;">
+                                                                <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{logo_src}"
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
-                                                                        width="50" alt="">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;outline:none;text-decoration:none;height:50px;font-size:13px;"
+                                                                         alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -212,16 +212,16 @@
                                         <tbody>
                                             <tr>
                                                 <td align="center"
-                                                    style="font-size:0px;padding:10px 100px;word-break:break-word;">
+                                                    style="font-size:0px;padding:10px;word-break:break-word;">
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                                         style="border-collapse:collapse;border-spacing:0px;">
                                                         <tbody>
                                                             <tr>
                                                                 <td style="width:100%;">
                                                                     <img height="auto"
-                                                                        src="{banner_src}"
-                                                                        alt=""
-                                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;">
+                                                                         src="{logo_src}"
+                                                                         style="border:0;display:block;outline:none;text-decoration:none;width:100%;font-size:13px;"
+                                                                         alt="">
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -257,7 +257,7 @@
                     style="width:100%;">
                     <tbody>
                         <tr>
-                            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                            <td style="direction:ltr;font-size:0px;padding:20px;text-align:center;">
                                 <!--[if mso | IE]>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tr>


### PR DESCRIPTION
1. Google font is optional in email settings. if it's not set then it should not load the google font.
2. Logo & banner size is not matching for all email templates
3. Discount notify template is floated to left side