### PR TITLE
fix(email): remove unnecessary min-width from email buttons

### DIFF
--- a/Core/Emails/views/discount-reminder.php
+++ b/Core/Emails/views/discount-reminder.php
@@ -343,7 +343,7 @@
                                                         <td align="center" role="presentation"
                                                             style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
                                                             valign="middle">
-                                                            <p style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:14px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;">
+                                                            <p style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:14px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;">
                                                                 {button_text}
                                                             </p>
                                                         </td>

--- a/Core/Emails/views/photo-request.php
+++ b/Core/Emails/views/photo-request.php
@@ -282,7 +282,7 @@
                                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                                 valign="middle">
                                                                                 <p
-                                                                                    style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                                    style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:6px;">
                                                                                     {button_text}
                                                                                 </p>
                                                                             </td>

--- a/Core/Emails/views/plain/discount-reminder.php
+++ b/Core/Emails/views/plain/discount-reminder.php
@@ -343,7 +343,7 @@
                                             <td align="center" role="presentation"
                                                 style="border:3px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:3px;cursor:auto;mso-padding-alt:10px 50px;"
                                                 valign="middle">
-                                                <p style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:14px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 50px;mso-padding-alt:0px;">
+                                                <p style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:14px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;">
                                                     {button_text}
                                                 </p>
                                             </td>

--- a/Core/Emails/views/plain/photo-request.php
+++ b/Core/Emails/views/plain/photo-request.php
@@ -282,7 +282,7 @@
                                                                 style="border:4px solid <?php echo esc_attr($data['styles']['button_border_color']); ?>;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;"
                                                                 valign="middle">
                                                                 <p
-                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;">
+                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']); ?>;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:6px;">
                                                                     {button_text}
                                                                 </p>
                                                             </td>

--- a/Core/Emails/views/plain/review-reminder.php
+++ b/Core/Emails/views/plain/review-reminder.php
@@ -353,7 +353,7 @@
                         <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                        <div class="mj-column-per-25 mj-outlook-group-fix"
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
                              style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                             <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                    style="vertical-align:top;" width="100%">
@@ -378,7 +378,7 @@
                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                     valign="middle">
                                                     <a href="<?php echo $reviewLink ?>"
-                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
                                                        target="_blank">
                                                         {button_text}
                                                     </a>

--- a/Core/Emails/views/plain/review-request.php
+++ b/Core/Emails/views/plain/review-request.php
@@ -74,10 +74,9 @@
                 max-width: 100%;
             }
 
-            .mj-column-per-25 {
-                width: 25% !important;
-                max-width: 25%;
-            }
+            mj-column-per-25                width: 25% !important;
+            max-width: 25%;
+        }
         }
     </style>
     <style media="screen and (min-width:480px)">
@@ -349,8 +348,8 @@
                         <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                        <div class="mj-column-per-25 mj-outlook-group-fix"
-                             style="font-size:0px;text-align:center;direction:ltr;display:inline-block;vertical-align:top;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+                        <div class="mj-column-per-100 mj-outlook-group-fix"
+                             style="font-size:0px;width:100%;text-align:center;direction:ltr;display:inline-block;vertical-align:top;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
                             <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                    style="vertical-align:top;" width="100%">
                                 <tbody>
@@ -374,7 +373,12 @@
                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                     valign="middle">
                                                     <a href="<?php echo $reviewLink ?>"
-                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;
+                                                               color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;
+                                                               font-size:13px;line-height:120%;margin:0;text-decoration:none;
+                                                               text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;
+                                                               border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>;
+                                                               text-align:center;"
                                                        target="_blank">
                                                         {button_text}
                                                     </a>

--- a/Core/Emails/views/review-reminder.php
+++ b/Core/Emails/views/review-reminder.php
@@ -353,7 +353,7 @@
                                     <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                                    <div class="mj-column-per-25 mj-outlook-group-fix"
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
                                         style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                             style="vertical-align:top;" width="100%">
@@ -378,7 +378,7 @@
                                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                                     valign="middle">
                                                                     <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
+                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
                                                                         target="_blank">
                                                                         {button_text}
                                                                     </a>

--- a/Core/Emails/views/review-request.php
+++ b/Core/Emails/views/review-request.php
@@ -74,8 +74,7 @@
                 max-width: 100%;
             }
 
-            .mj-column-per-25 {
-                width: 25% !important;
+            mj-column-per-25                width: 25% !important;
                 max-width: 25%;
             }
         }
@@ -349,8 +348,8 @@
                                     <!--[if mso | IE]>
                         <td class="" style="vertical-align:top;width:150px;">
                         <![endif]-->
-                                    <div class="mj-column-per-25 mj-outlook-group-fix"
-                                        style="font-size:0px;text-align:center;direction:ltr;display:inline-block;vertical-align:top;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                        style="font-size:0px;width:100%;text-align:center;direction:ltr;display:inline-block;vertical-align:top;background-color: <?php echo esc_attr($data['styles']['email_content_bg_color']); ?>;">
                                         <table border="0" cellpadding="0" cellspacing="0" role="presentation"
                                             style="vertical-align:top;" width="100%">
                                             <tbody>
@@ -374,8 +373,13 @@
                                                                     style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;"
                                                                     valign="middle">
                                                                     <a href="<?php echo $reviewLink ?>"
-                                                                        style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;min-width:max-content;font-size:13px;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>"
-                                                                        target="_blank">
+                                                                       style="display:inline-block;background-color:<?php echo esc_attr($data['styles']['button_bg_color']); ?>;
+                                                                               color:<?php echo esc_attr($data['styles']['button_text_color']) ?>;
+                                                                               font-size:13px;line-height:120%;margin:0;text-decoration:none;
+                                                                               text-transform:none;padding:10px;mso-padding-alt:0px;border-radius:3px;
+                                                                               border:3px solid <?php echo esc_attr($data['styles']['button_border_color']) ?>;
+                                                                               text-align:center;"
+                                                                       target="_blank">
                                                                         {button_text}
                                                                     </a>
                                                                 </td>


### PR DESCRIPTION
Removed the `min-width:max-content` style from email buttons, as it is redundant and can cause layout issues in some email clients. This change ensures consistent button rendering across different email platforms.